### PR TITLE
fix(ci): install kustomize in deploy job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -222,6 +222,11 @@ jobs:
         with:
           version: 'v1.28.0'
 
+      - name: Set up kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: '5.4.3'
+
       - name: Configure kubeconfig
         run: |
           mkdir -p ~/.kube


### PR DESCRIPTION
## Summary

- The deploy job calls `kustomize edit set image ...` but kustomize is never installed on the runner. `azure/setup-kubectl@v3` only provides `kubectl`, not the standalone `kustomize` binary.
- Every CEQ Deploy run since the workflow was introduced fails with:
  ```
  kustomize: command not found
  ##[error]Process completed with exit code 127.
  ```
  ([run 24586008945](https://github.com/madfam-org/ceq/actions/runs/24586008945))
- Fix: add `imranismail/setup-kustomize@v2` step right after kubectl setup, matching the pattern already in use in avala's Build & Deploy workflow.

## Test plan

- [ ] Next push to `main` (or manual dispatch of `CEQ Deploy`) gets past the "Update image tags in kustomization" step.
- [ ] `kubectl apply -k infrastructure/k8s/` runs with the updated image tags.
- [ ] `ceq-api` and `ceq-studio` rollouts complete.

## Scope

Single-file diff in `.github/workflows/deploy.yaml`. No other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)