### PR TITLE
chore(render): audit gaps — dead import, SDK edge-case test, top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **ceq** wraps the raw power of [ComfyUI](https://github.com/comfyanonymous/ComfyUI) with a streamlined, hacker-centric interface. Full node power when you need it, a clean UX when you don't.
 
 **Domain:** [ceq.lol](https://ceq.lol)
-**Status:** Pre-production (Infrastructure pending)
+**Status:** Live — studio + API deployed; `/v1/render` pipeline shipped 2026-04-19
 **Philosophy:** *Wrestling order from the chaos of latent space*
 
 ---
@@ -18,6 +18,7 @@ CEQ is MADFAM's internal content generation platform. It enables:
 - **Video Clones**: AI-generated spokesperson content
 - **3D Renders**: Product visualization and creative assets
 - **Brand Consistency**: MADFAM aesthetic across all outputs
+- **Generic asset rendering (`/v1/render/*`)**: Deterministic, content-addressed cards / thumbnails for any MADFAM service that needs a stable URL — see [`@ceq/sdk`](./packages/sdk/README.md) and [API docs](./apps/api/README.md#render-generative-assets).
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -178,21 +179,22 @@ CEQ is deployed to Enclii infrastructure via Cloudflare Tunnels:
 
 | Domain | Service | Status |
 |--------|---------|--------|
-| ceq.lol | Studio | Pending |
-| api.ceq.lol | API | Pending |
-| ws.ceq.lol | WebSocket | Pending |
+| ceq.lol | Studio | Live (2 pods) |
+| api.ceq.lol | API | Live (2 pods) |
+| ws.ceq.lol | WebSocket | Configured |
 
 See [docs/PRODUCTION_DEPLOYMENT.md](./docs/PRODUCTION_DEPLOYMENT.md) for detailed deployment guide.
 
-### Deployment Status (2025-12-10)
+### Deployment Status (2026-04-19)
 
 | Component | Status |
 |-----------|--------|
 | Janua OAuth Client | Registered |
-| Cloudflare R2 Bucket | Created |
+| Cloudflare R2 Bucket | Live (`ceq-assets`; render cache under `render/{template}/{hash}.{ext}`) |
 | Cloudflare Tunnel Routes | Configured |
-| K8s Secrets | Partial (DB/Redis pending) |
-| Infrastructure | Pending (Terraform not run) |
+| `/v1/render/*` pipeline | Shipped — card renderer + R2 cache + `@ceq/sdk` |
+| K8s Secrets | Applied |
+| Infrastructure | Live on Enclii k3s |
 
 ---
 
@@ -214,8 +216,9 @@ CEQ uses [Janua](https://github.com/madfam-io/janua) for authentication:
 |----------|-------------|
 | [docs/PRD.md](./docs/PRD.md) | Product requirements & manifesto |
 | [docs/PRODUCTION_DEPLOYMENT.md](./docs/PRODUCTION_DEPLOYMENT.md) | Production deployment guide |
-| [apps/api/README.md](./apps/api/README.md) | API documentation |
+| [apps/api/README.md](./apps/api/README.md) | API documentation (incl. `/v1/render/*` contract) |
 | [apps/workers/README.md](./apps/workers/README.md) | GPU worker documentation |
+| [packages/sdk/README.md](./packages/sdk/README.md) | `@ceq/sdk` — JS/TS client for the render API |
 | [CLAUDE.md](./CLAUDE.md) | Agent/developer instructions |
 
 ---

--- a/apps/api/src/ceq_api/render/renderers/card.py
+++ b/apps/api/src/ceq_api/render/renderers/card.py
@@ -11,13 +11,11 @@ invalidated.
 from __future__ import annotations
 
 import io
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from PIL import Image, ImageDraw, ImageFont
-
 
 # Font resolution: bundled → system DejaVu (prod Linux) → platform fallbacks (dev).
 _BUNDLED_FONT_DIR = Path(__file__).parent.parent / "assets" / "fonts"
@@ -126,7 +124,7 @@ class CardData:
     badge: str = ""  # short rarity tag e.g. "R", "SR", "★★★"
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "CardData":
+    def from_dict(cls, data: dict[str, Any]) -> CardData:
         allowed = {"title", "subtitle", "description", "accent", "glyph", "badge"}
         if not data.get("title"):
             raise ValueError("card.title is required")

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -142,4 +142,23 @@ describe("CeqApiError", () => {
     expect(err.message).toContain("500");
     expect(err.message).toContain("boom");
   });
+
+  it("falls back to statusText when the error body is not JSON", async () => {
+    // Non-JSON body (e.g. HTML 502 page, plaintext gateway error).
+    // The SDK's body.json() call throws; detail should fall back to statusText.
+    const fetchImpl: typeof fetch = vi.fn(async () =>
+      new Response("<html>bad gateway</html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "text/html" },
+      })
+    ) as unknown as typeof fetch;
+
+    const ceq = new CeqClient({ fetch: fetchImpl });
+    await expect(ceq.listTemplates()).rejects.toMatchObject({
+      name: "CeqApiError",
+      status: 502,
+      detail: "Bad Gateway",
+    });
+  });
 });


### PR DESCRIPTION
## Post-ship audit pass on the render pipeline (62fcfe9 + 05c28b3).

### Gaps closed

- **Dead import**: `import os` in `apps/api/src/ceq_api/render/renderers/card.py` was unused and failing `ruff check` (F401). Module was net-new in 62fcfe9, so the fix ships with the feature. Incidentally cleans up two ruff autofixes on the same file (I001 import ordering, UP037 quoted forward-ref) that were introduced in the same commit.
- **SDK test coverage**: the non-JSON error body branch in `client.ts:136-141` (response ok=false + body.json() throws) had no explicit test. Added a 502/HTML body test that asserts `CeqApiError.detail` falls back to `statusText`.
- **Top-level README**: was still "Pre-production (Infrastructure pending)" and didn't mention `/v1/render/*` or `@ceq/sdk`. Refreshed status line, added render/SDK callouts to the feature list + Documentation table, and updated the dated deployment-status block to 2026-04-19.

### Verification

- `ruff check src/ceq_api/render/` → All checks passed
- `pytest tests/test_render.py` → 22 passed
- `pnpm test` in `packages/sdk` → 8 passed (was 7, +1 for the new edge-case)

### Not changed

- `apps/api/README.md`, `packages/sdk/README.md`, and `.env.example` already cover the render surface from the 05c28b3 pass — re-verified, no changes needed.