### PR TITLE
feat(render): audio tone-beep + 3d card-plate renderers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,17 @@
 
 ## Asset-pillar surface (shipped 2026-04-19)
 
-`POST /v1/render/card`, `/thumbnail`, `/audio` (501), `/3d` (501), `GET /v1/render/templates` — deterministic, content-addressed, R2-cached. Identical inputs always return the same URL. See `apps/api/README.md#render-generative-assets` for the full contract.
+`POST /v1/render/card`, `/thumbnail`, `/audio`, `/3d`, `GET /v1/render/templates` — deterministic, content-addressed, R2-cached. Identical inputs always return the same URL. See `apps/api/README.md#render-generative-assets` for the full contract.
 
-Client: `@ceq/sdk` (`packages/sdk/`) — `CeqClient.renderCard({...})` for JS/TS consumers. First external consumer: Rondelio's stratum-tcg cartridge (`services/simulator/cartridges/stratum-tcg/scripts/generate_art.py`, `--provider ceq`).
+Built-in templates (as of 2026-04-19):
+
+| Endpoint | Template | Output | Notes |
+|---|---|---|---|
+| `/v1/render/card` | `card-standard` | 512×768 PNG | Pillow-rendered card thumbnail |
+| `/v1/render/audio` | `tone-beep` | 16-bit PCM WAV @ 22.05kHz | Parametric sine + ADSR envelope (stdlib) |
+| `/v1/render/3d` | `card-plate` | GLB (glTF 2.0 binary) | Parametric rounded-rectangle plate (stdlib writer) |
+
+Client: `@ceq/sdk` (`packages/sdk/`) — `CeqClient.renderCard/renderAudio/render3D({...})` for JS/TS consumers. First external consumer: Rondelio's stratum-tcg cartridge (`services/simulator/cartridges/stratum-tcg/scripts/generate_art.py`, `--provider ceq`).
 
 ## Architecture
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -91,9 +91,9 @@ records (e.g. card thumbnails on Rondelio card records).
 |--------|----------|-------------|
 | `POST` | `/v1/render/card` | Render card-standard thumbnail (512×768 PNG) |
 | `POST` | `/v1/render/thumbnail` | Generic render; caller supplies template name |
+| `POST` | `/v1/render/audio` | Render audio asset (`audio/wav`). Default template: `tone-beep` — parametric sine + ADSR envelope |
+| `POST` | `/v1/render/3d` | Render 3D asset (`model/gltf-binary`). Default template: `card-plate` — parametric rounded-rectangle plate |
 | `GET` | `/v1/render/templates` | List available templates + versions |
-| `POST` | `/v1/render/audio` | **501** — reserved for future audio generation |
-| `POST` | `/v1/render/3d` | **501** — reserved for future 3D generation |
 
 Request shape:
 ```json

--- a/apps/api/src/ceq_api/render/renderers/__init__.py
+++ b/apps/api/src/ceq_api/render/renderers/__init__.py
@@ -44,9 +44,13 @@ registry = RendererRegistry()
 
 
 def _load_builtins() -> None:
+    from ceq_api.render.renderers.audio_tone_beep import ToneBeepRenderer
     from ceq_api.render.renderers.card import CardStandardRenderer
+    from ceq_api.render.renderers.card_plate_3d import CardPlateRenderer
 
     registry.register(CardStandardRenderer())
+    registry.register(ToneBeepRenderer())
+    registry.register(CardPlateRenderer())
 
 
 _load_builtins()

--- a/apps/api/src/ceq_api/render/renderers/audio_tone_beep.py
+++ b/apps/api/src/ceq_api/render/renderers/audio_tone_beep.py
@@ -1,0 +1,147 @@
+"""Tone-beep audio renderer.
+
+Produces a deterministic WAV file — 16-bit PCM, 22.05kHz mono — from a
+frequency, duration, envelope shape, and volume. Useful for app
+notification sounds, confirmation chimes, and card-interaction feedback
+where a deterministic, cache-friendly asset URL beats bundling audio
+files with the client.
+
+This is intentionally *not* a TTS / neural-audio generator. The contract
+is "parametric synthesis in pure stdlib" — zero external API deps, zero
+credentials, zero per-call cost. Neural audio can be a future template
+(e.g. `tts-neural`) once there's a caller who needs it.
+
+Bump `version` when output bytes would change so cached renders are
+invalidated.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+import struct
+import wave
+from dataclasses import dataclass
+from typing import Any
+
+_SAMPLE_RATE_HZ = 22050
+_SAMPLE_WIDTH_BYTES = 2  # 16-bit PCM
+_CHANNELS = 1  # mono
+_MAX_AMPLITUDE = 32767  # int16 max, leaves 1 count of headroom
+
+_ENVELOPES = ("adsr-gentle", "adsr-sharp", "linear", "square")
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+@dataclass(frozen=True)
+class ToneBeepData:
+    frequency_hz: float
+    duration_ms: int
+    envelope: str
+    volume: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToneBeepData:
+        freq = _clamp(float(data.get("frequency_hz", 880)), 20.0, 20000.0)
+        dur = int(_clamp(float(data.get("duration_ms", 200)), 10.0, 5000.0))
+        env = str(data.get("envelope", "adsr-gentle"))
+        if env not in _ENVELOPES:
+            raise ValueError(
+                f"invalid envelope: {env!r} (must be one of {_ENVELOPES})"
+            )
+        vol = _clamp(float(data.get("volume", 0.5)), 0.0, 1.0)
+        return cls(frequency_hz=freq, duration_ms=dur, envelope=env, volume=vol)
+
+
+def _envelope_at(
+    sample_index: int,
+    total_samples: int,
+    envelope: str,
+) -> float:
+    """
+    Return the envelope amplitude multiplier in [0, 1] for a given sample.
+
+    Envelopes are expressed as proportions of the total sample window so
+    short and long tones share the same perceptual shape.
+    """
+    if total_samples <= 1:
+        return 1.0
+    t = sample_index / (total_samples - 1)  # [0, 1]
+
+    if envelope == "square":
+        # Brick-wall gate — full amplitude the whole way, click at the ends.
+        return 1.0
+
+    if envelope == "linear":
+        # Triangle window: 0 → 1 → 0 across the tone.
+        return 1.0 - abs(2.0 * t - 1.0)
+
+    if envelope == "adsr-sharp":
+        # 2% attack, 8% decay to 0.7 sustain, 20% release.
+        attack_end = 0.02
+        decay_end = 0.10
+        release_start = 0.80
+        sustain_level = 0.7
+    else:  # adsr-gentle (default)
+        # 10% attack, 15% decay to 0.8 sustain, 25% release.
+        attack_end = 0.10
+        decay_end = 0.25
+        release_start = 0.75
+        sustain_level = 0.8
+
+    if t < attack_end:
+        return t / attack_end
+    if t < decay_end:
+        span = decay_end - attack_end
+        progress = (t - attack_end) / span
+        return 1.0 - progress * (1.0 - sustain_level)
+    if t < release_start:
+        return sustain_level
+    # Release: sustain_level → 0 over remaining window.
+    span = 1.0 - release_start
+    progress = (t - release_start) / span
+    return sustain_level * (1.0 - progress)
+
+
+class ToneBeepRenderer:
+    """Stdlib tone synthesizer — 16-bit PCM WAV."""
+
+    template = "tone-beep"
+    version = "1"
+    content_type = "audio/wav"
+    extension = "wav"
+
+    def render(self, data: dict[str, Any]) -> bytes:
+        params = ToneBeepData.from_dict(data)
+
+        total_samples = int(_SAMPLE_RATE_HZ * params.duration_ms / 1000)
+        # Guard against pathological inputs. Minimum 1 sample so wave.open is happy.
+        total_samples = max(total_samples, 1)
+
+        angular_step = 2.0 * math.pi * params.frequency_hz / _SAMPLE_RATE_HZ
+        peak = _MAX_AMPLITUDE * params.volume
+
+        # Pre-build the int16 sample buffer with struct.pack for deterministic bytes.
+        frames = bytearray(total_samples * _SAMPLE_WIDTH_BYTES)
+        for i in range(total_samples):
+            envelope_gain = _envelope_at(i, total_samples, params.envelope)
+            sample_value = peak * envelope_gain * math.sin(angular_step * i)
+            # Round-half-to-even for determinism across platforms (Python's default).
+            int_sample = int(round(sample_value))
+            # Clamp to int16 range in case of any float edge case.
+            if int_sample > _MAX_AMPLITUDE:
+                int_sample = _MAX_AMPLITUDE
+            elif int_sample < -_MAX_AMPLITUDE - 1:
+                int_sample = -_MAX_AMPLITUDE - 1
+            struct.pack_into("<h", frames, i * _SAMPLE_WIDTH_BYTES, int_sample)
+
+        out = io.BytesIO()
+        with wave.open(out, "wb") as wav:
+            wav.setnchannels(_CHANNELS)
+            wav.setsampwidth(_SAMPLE_WIDTH_BYTES)
+            wav.setframerate(_SAMPLE_RATE_HZ)
+            wav.writeframes(bytes(frames))
+        return out.getvalue()

--- a/apps/api/src/ceq_api/render/renderers/card_plate_3d.py
+++ b/apps/api/src/ceq_api/render/renderers/card_plate_3d.py
@@ -1,0 +1,423 @@
+"""Card-plate 3D renderer.
+
+Produces a parametric rectangular plate with rounded corners as a GLB
+(glTF 2.0 binary). The 3D equivalent of the card-standard template —
+useful as a physical-prototype preview target, a 3D card holder in an
+AR viewer, or a base mesh for downstream procedural texturing.
+
+Output:
+  - Binary glTF 2.0 (GLB) with magic "glTF" + version 2
+  - One mesh, one PBR material (metallic-roughness, baseColorFactor from accent)
+  - Position + normal attributes, indexed triangle mesh
+  - Units in millimeters (mesh scale preserves the input mm values; consumers
+    can interpret as mm or apply their own unit conversion)
+
+Hand-rolled glTF writer (stdlib only). Deterministic: identical input
+params → identical GLB bytes. No floating-point nondeterminism because
+we pre-compute vertex positions from integer tessellation and pack with
+a fixed struct format.
+
+Bump `version` when output bytes would change so cached renders are
+invalidated.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+# --- glTF binary constants ---------------------------------------------------
+
+_GLB_MAGIC = 0x46546C67  # "glTF"
+_GLB_VERSION = 2
+_CHUNK_JSON = 0x4E4F534A  # "JSON"
+_CHUNK_BIN = 0x004E4942  # "BIN\0"
+
+# glTF componentType enums
+_COMPONENT_UNSIGNED_INT = 5125
+_COMPONENT_FLOAT = 5126
+
+# glTF primitive modes
+_MODE_TRIANGLES = 4
+
+# Corner tessellation — fixed count per quadrant for deterministic output.
+# 8 segments per quadrant → smooth enough corners without bloating the mesh.
+_CORNER_SEGMENTS = 8
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _hex_to_rgb_float(value: str) -> tuple[float, float, float]:
+    raw = value.lstrip("#")
+    if len(raw) == 3:
+        raw = "".join(c * 2 for c in raw)
+    if len(raw) != 6:
+        raise ValueError(f"invalid hex color: {value!r}")
+    try:
+        r = int(raw[0:2], 16)
+        g = int(raw[2:4], 16)
+        b = int(raw[4:6], 16)
+    except ValueError as exc:
+        raise ValueError(f"invalid hex color: {value!r}") from exc
+    return r / 255.0, g / 255.0, b / 255.0
+
+
+@dataclass(frozen=True)
+class CardPlateData:
+    width_mm: float
+    height_mm: float
+    thickness_mm: float
+    corner_radius_mm: float
+    accent_hex: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CardPlateData:
+        width = _clamp(float(data.get("width_mm", 63.5)), 10.0, 300.0)
+        height = _clamp(float(data.get("height_mm", 88.9)), 10.0, 300.0)
+        thickness = _clamp(float(data.get("thickness_mm", 2.0)), 0.5, 20.0)
+        radius = _clamp(float(data.get("corner_radius_mm", 4.0)), 0.0, 20.0)
+        accent = str(data.get("accent_hex", "#3C8CFF"))
+        # Validate hex early so render-time failures surface as 422, not 500.
+        _hex_to_rgb_float(accent)
+        # Corner radius can't exceed half of the smaller dimension.
+        max_radius = min(width, height) / 2.0
+        if radius > max_radius:
+            radius = max_radius
+        return cls(
+            width_mm=width,
+            height_mm=height,
+            thickness_mm=thickness,
+            corner_radius_mm=radius,
+            accent_hex=accent,
+        )
+
+
+# --- rounded-rectangle tessellation ------------------------------------------
+
+
+def _rounded_rect_outline(
+    width: float,
+    height: float,
+    radius: float,
+    corner_segments: int,
+) -> list[tuple[float, float]]:
+    """
+    Return the 2D outline of a rounded rectangle centered at the origin,
+    as an ordered list of (x, y) points forming a closed polygon. Points
+    are ordered counter-clockwise so the top face (+Z) has outward normals.
+    """
+    hw = width / 2.0
+    hh = height / 2.0
+    r = radius
+
+    # If radius is zero, return the four corners directly.
+    if r == 0.0:
+        return [(-hw, -hh), (hw, -hh), (hw, hh), (-hw, hh)]
+
+    points: list[tuple[float, float]] = []
+
+    # Corner centers (CCW from bottom-right).
+    corners = [
+        (hw - r, -hh + r, -math.pi / 2.0, 0.0),           # bottom-right: 270° → 360°
+        (hw - r, hh - r, 0.0, math.pi / 2.0),             # top-right:     0° →  90°
+        (-hw + r, hh - r, math.pi / 2.0, math.pi),        # top-left:     90° → 180°
+        (-hw + r, -hh + r, math.pi, 3.0 * math.pi / 2.0), # bottom-left: 180° → 270°
+    ]
+
+    for cx, cy, start_angle, end_angle in corners:
+        span = end_angle - start_angle
+        for i in range(corner_segments + 1):
+            t = i / corner_segments
+            angle = start_angle + span * t
+            x = cx + r * math.cos(angle)
+            y = cy + r * math.sin(angle)
+            # Avoid duplicating the shared vertex between adjacent arcs.
+            if points and points[-1] == (x, y):
+                continue
+            points.append((x, y))
+
+    # Close the polygon by dropping the last point if it duplicates the first.
+    if len(points) >= 2 and points[-1] == points[0]:
+        points.pop()
+
+    return points
+
+
+def _triangle_fan_indices(center_index: int, ring_indices: list[int]) -> list[int]:
+    """Generate triangle indices fanning from `center_index` over a closed ring."""
+    indices: list[int] = []
+    n = len(ring_indices)
+    for i in range(n):
+        a = ring_indices[i]
+        b = ring_indices[(i + 1) % n]
+        indices.extend([center_index, a, b])
+    return indices
+
+
+def _build_mesh(data: CardPlateData) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]], list[int]]:
+    """
+    Tessellate the rounded plate.
+
+    Returns (positions, normals, indices):
+      - positions: list of (x, y, z) in millimeters
+      - normals: list of (nx, ny, nz) unit vectors, one per position
+      - indices: flat triangle list
+    """
+    outline = _rounded_rect_outline(
+        data.width_mm, data.height_mm, data.corner_radius_mm, _CORNER_SEGMENTS
+    )
+    half_thickness = data.thickness_mm / 2.0
+
+    positions: list[tuple[float, float, float]] = []
+    normals: list[tuple[float, float, float]] = []
+    indices: list[int] = []
+
+    # --- top face (+Z) ---
+    # Fan from a center vertex so the top is one connected triangle fan.
+    top_center_idx = len(positions)
+    positions.append((0.0, 0.0, half_thickness))
+    normals.append((0.0, 0.0, 1.0))
+    top_ring_start = len(positions)
+    for x, y in outline:
+        positions.append((x, y, half_thickness))
+        normals.append((0.0, 0.0, 1.0))
+    top_ring = list(range(top_ring_start, top_ring_start + len(outline)))
+    indices.extend(_triangle_fan_indices(top_center_idx, top_ring))
+
+    # --- bottom face (-Z) ---
+    # Same shape, but fan winding reversed so normals point -Z outward.
+    bot_center_idx = len(positions)
+    positions.append((0.0, 0.0, -half_thickness))
+    normals.append((0.0, 0.0, -1.0))
+    bot_ring_start = len(positions)
+    for x, y in outline:
+        positions.append((x, y, -half_thickness))
+        normals.append((0.0, 0.0, -1.0))
+    bot_ring = list(range(bot_ring_start, bot_ring_start + len(outline)))
+    # Reverse winding for downward-facing face.
+    for tri_start in range(0, len(_triangle_fan_indices(bot_center_idx, bot_ring)), 3):
+        fan_indices = _triangle_fan_indices(bot_center_idx, bot_ring)
+        tri = fan_indices[tri_start:tri_start + 3]
+        indices.extend([tri[0], tri[2], tri[1]])
+
+    # --- side walls ---
+    # Each outline edge becomes a quad (two triangles) with outward-facing normals.
+    # Use *separate* vertices for the walls so per-face normals are correct —
+    # sharing top/bottom ring vertices would smear the normal across the edge.
+    n = len(outline)
+    for i in range(n):
+        x0, y0 = outline[i]
+        x1, y1 = outline[(i + 1) % n]
+        # Outward normal = cross((edge, 0), (0, 0, 1)) normalized.
+        # For CCW-ordered outline viewed from +Z, outward = (dy, -dx, 0) normalized.
+        dx = x1 - x0
+        dy = y1 - y0
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            # Degenerate edge — skip. Shouldn't happen given tessellation.
+            continue
+        nx = dy / length
+        ny = -dx / length
+        normal = (nx, ny, 0.0)
+
+        # 4 new vertices for this wall quad.
+        base = len(positions)
+        positions.append((x0, y0, half_thickness))
+        positions.append((x1, y1, half_thickness))
+        positions.append((x1, y1, -half_thickness))
+        positions.append((x0, y0, -half_thickness))
+        for _ in range(4):
+            normals.append(normal)
+
+        # Two triangles, CCW when viewed from outside.
+        indices.extend([base + 0, base + 3, base + 2])
+        indices.extend([base + 0, base + 2, base + 1])
+
+    return positions, normals, indices
+
+
+# --- glTF binary serialization -----------------------------------------------
+
+
+def _write_glb(
+    positions: list[tuple[float, float, float]],
+    normals: list[tuple[float, float, float]],
+    indices: list[int],
+    base_color: tuple[float, float, float],
+) -> bytes:
+    """Serialize mesh to a minimal GLB (glTF 2.0 binary) file."""
+    # Build binary buffer: positions | normals | indices.
+    # Each section is 4-byte aligned (glTF requires alignment per componentType).
+    pos_bytes = bytearray()
+    for x, y, z in positions:
+        pos_bytes += struct.pack("<fff", x, y, z)
+
+    norm_bytes = bytearray()
+    for nx, ny, nz in normals:
+        norm_bytes += struct.pack("<fff", nx, ny, nz)
+
+    idx_bytes = bytearray()
+    for i in indices:
+        idx_bytes += struct.pack("<I", i)
+
+    # Pad each section up to a 4-byte boundary.
+    def _pad4(buf: bytearray) -> bytearray:
+        remainder = len(buf) % 4
+        if remainder:
+            buf += b"\x00" * (4 - remainder)
+        return buf
+
+    pos_bytes = _pad4(pos_bytes)
+    norm_bytes = _pad4(norm_bytes)
+    idx_bytes = _pad4(idx_bytes)
+
+    pos_offset = 0
+    norm_offset = pos_offset + len(pos_bytes)
+    idx_offset = norm_offset + len(norm_bytes)
+    total_bin_length = idx_offset + len(idx_bytes)
+
+    # Bounding box for positions (required for POSITION accessor min/max).
+    min_pos = [positions[0][0], positions[0][1], positions[0][2]]
+    max_pos = [positions[0][0], positions[0][1], positions[0][2]]
+    for x, y, z in positions:
+        if x < min_pos[0]:
+            min_pos[0] = x
+        if y < min_pos[1]:
+            min_pos[1] = y
+        if z < min_pos[2]:
+            min_pos[2] = z
+        if x > max_pos[0]:
+            max_pos[0] = x
+        if y > max_pos[1]:
+            max_pos[1] = y
+        if z > max_pos[2]:
+            max_pos[2] = z
+
+    gltf_json: dict[str, Any] = {
+        "asset": {"version": "2.0", "generator": "ceq-card-plate-3d"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"mesh": 0}],
+        "meshes": [
+            {
+                "primitives": [
+                    {
+                        "attributes": {
+                            "POSITION": 0,
+                            "NORMAL": 1,
+                        },
+                        "indices": 2,
+                        "material": 0,
+                        "mode": _MODE_TRIANGLES,
+                    }
+                ]
+            }
+        ],
+        "materials": [
+            {
+                "pbrMetallicRoughness": {
+                    "baseColorFactor": [
+                        base_color[0],
+                        base_color[1],
+                        base_color[2],
+                        1.0,
+                    ],
+                    "metallicFactor": 0.1,
+                    "roughnessFactor": 0.7,
+                },
+                "doubleSided": False,
+            }
+        ],
+        "buffers": [{"byteLength": total_bin_length}],
+        "bufferViews": [
+            {
+                "buffer": 0,
+                "byteOffset": pos_offset,
+                "byteLength": len(pos_bytes),
+                "target": 34962,  # ARRAY_BUFFER
+            },
+            {
+                "buffer": 0,
+                "byteOffset": norm_offset,
+                "byteLength": len(norm_bytes),
+                "target": 34962,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": idx_offset,
+                "byteLength": len(idx_bytes),
+                "target": 34963,  # ELEMENT_ARRAY_BUFFER
+            },
+        ],
+        "accessors": [
+            {
+                "bufferView": 0,
+                "componentType": _COMPONENT_FLOAT,
+                "count": len(positions),
+                "type": "VEC3",
+                "min": min_pos,
+                "max": max_pos,
+            },
+            {
+                "bufferView": 1,
+                "componentType": _COMPONENT_FLOAT,
+                "count": len(normals),
+                "type": "VEC3",
+            },
+            {
+                "bufferView": 2,
+                "componentType": _COMPONENT_UNSIGNED_INT,
+                "count": len(indices),
+                "type": "SCALAR",
+            },
+        ],
+    }
+
+    # Serialize JSON with sorted keys + tight separators for deterministic bytes.
+    json_bytes = json.dumps(
+        gltf_json, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    # JSON chunk must be padded with spaces (0x20) to 4-byte alignment.
+    json_pad = (4 - len(json_bytes) % 4) % 4
+    json_bytes += b" " * json_pad
+
+    # BIN chunk (already padded above).
+    bin_bytes = bytes(pos_bytes + norm_bytes + idx_bytes)
+
+    # Compose GLB:
+    # Header (12 bytes): magic, version, total length
+    # JSON chunk: length (4) + type (4) + data
+    # BIN chunk:  length (4) + type (4) + data
+    total_length = (
+        12  # header
+        + 8 + len(json_bytes)
+        + 8 + len(bin_bytes)
+    )
+
+    out = bytearray()
+    out += struct.pack("<III", _GLB_MAGIC, _GLB_VERSION, total_length)
+    out += struct.pack("<II", len(json_bytes), _CHUNK_JSON)
+    out += json_bytes
+    out += struct.pack("<II", len(bin_bytes), _CHUNK_BIN)
+    out += bin_bytes
+    return bytes(out)
+
+
+class CardPlateRenderer:
+    """Parametric rounded-rectangle plate → GLB (glTF 2.0 binary)."""
+
+    template = "card-plate"
+    version = "1"
+    content_type = "model/gltf-binary"
+    extension = "glb"
+
+    def render(self, data: dict[str, Any]) -> bytes:
+        params = CardPlateData.from_dict(data)
+        positions, normals, indices = _build_mesh(params)
+        base_color = _hex_to_rgb_float(params.accent_hex)
+        return _write_glb(positions, normals, indices, base_color)

--- a/apps/api/src/ceq_api/routers/render.py
+++ b/apps/api/src/ceq_api/routers/render.py
@@ -4,9 +4,14 @@
 Deterministic, cached renders. Given a template + data, return a stable public
 URL. Identical inputs hit the R2 cache and skip re-rendering.
 
-This is CEQ's "generic renderer" surface — currently image-only (cards).
-Audio and 3D endpoints are stubs exposing the same request shape so callers
-can integrate against a stable contract while the backends are built out.
+Three asset families today:
+  - image: /v1/render/card, /v1/render/thumbnail  (Pillow-based)
+  - audio: /v1/render/audio                       (stdlib WAV synthesis)
+  - 3D:    /v1/render/3d                          (stdlib GLB writer)
+
+All three flow through a single generic dispatcher (`_render_asset`) — they
+differ only in which templates they accept. The cache, hash, and response
+shape are uniform across families.
 """
 
 from __future__ import annotations
@@ -66,7 +71,7 @@ async def render_card(
     user: Annotated[JanuaUser, Depends(get_current_user)],
     storage: Annotated[StorageClient, Depends(get_storage)],
 ) -> RenderResponse:
-    return await _render_image(
+    return await _render_asset(
         template=request.template or "card-standard",
         data=request.data,
         storage=storage,
@@ -87,7 +92,7 @@ async def render_thumbnail(
     user: Annotated[JanuaUser, Depends(get_current_user)],
     storage: Annotated[StorageClient, Depends(get_storage)],
 ) -> RenderResponse:
-    return await _render_image(
+    return await _render_asset(
         template=request.template,
         data=request.data,
         storage=storage,
@@ -120,55 +125,72 @@ async def list_templates(
     ]
 
 
-# ---------- stubs for broader ambition ----------
+# ---------- audio render ----------
 
 
 @router.post(
     "/audio",
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    summary="Render an audio asset (not yet implemented)",
+    response_model=RenderResponse,
+    summary="Render an audio asset",
     description=(
-        "Reserved for future audio generation. Returns 501 today. The request "
-        "shape matches other render endpoints so callers can integrate early."
+        "Render a deterministic audio asset (WAV). Current templates: "
+        "`tone-beep` (parametric sine-wave beep with ADSR envelopes — useful "
+        "for notification chimes and UI feedback sounds). Deterministic, "
+        "cached, same response shape as /card and /thumbnail."
     ),
 )
 async def render_audio(
     request: RenderRequest,
     user: Annotated[JanuaUser, Depends(get_current_user)],
-) -> dict[str, str]:
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="audio rendering not yet implemented; contract is stable, backend coming",
+    storage: Annotated[StorageClient, Depends(get_storage)],
+) -> RenderResponse:
+    return await _render_asset(
+        template=request.template or "tone-beep",
+        data=request.data,
+        storage=storage,
     )
+
+
+# ---------- 3D render ----------
 
 
 @router.post(
     "/3d",
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    summary="Render a 3D asset (not yet implemented)",
+    response_model=RenderResponse,
+    summary="Render a 3D asset",
     description=(
-        "Reserved for future 3D generation (GLB/USDZ). Returns 501 today. Use "
-        "/v1/workflows with the triposr-image-to-3d template for current 3D jobs."
+        "Render a deterministic 3D asset (GLB / glTF 2.0 binary). Current "
+        "templates: `card-plate` (parametric rounded-rectangle plate — 3D "
+        "counterpart to card-standard, useful as a physical-prototype preview "
+        "or AR card holder). Deterministic, cached, same response shape as "
+        "/card and /thumbnail."
     ),
 )
 async def render_3d(
     request: RenderRequest,
     user: Annotated[JanuaUser, Depends(get_current_user)],
-) -> dict[str, str]:
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="3D rendering not yet implemented; use /v1/workflows for ComfyUI-backed 3D jobs",
+    storage: Annotated[StorageClient, Depends(get_storage)],
+) -> RenderResponse:
+    return await _render_asset(
+        template=request.template or "card-plate",
+        data=request.data,
+        storage=storage,
     )
 
 
 # ---------- internal ----------
 
 
-async def _render_image(
+async def _render_asset(
     template: str,
     data: dict[str, Any],
     storage: StorageClient,
 ) -> RenderResponse:
+    """
+    Generic render dispatcher. Works for any registered renderer regardless
+    of output media — image/png, audio/wav, model/gltf-binary all flow through
+    the same hash + cache + response pipeline.
+    """
     try:
         renderer = registry.get(template)
     except KeyError:
@@ -191,7 +213,7 @@ async def _render_image(
     cached = await cache.exists(key)
     if not cached:
         try:
-            image_bytes = renderer.render(data)
+            asset_bytes = renderer.render(data)
         except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -205,7 +227,7 @@ async def _render_image(
             ) from None
 
         try:
-            await cache.put(key=key, body=image_bytes, content_type=renderer.content_type)
+            await cache.put(key=key, body=asset_bytes, content_type=renderer.content_type)
         except Exception:
             logger.exception("render cache write failed for key=%s", key)
             raise HTTPException(

--- a/apps/api/tests/test_3d_renderer.py
+++ b/apps/api/tests/test_3d_renderer.py
@@ -1,0 +1,243 @@
+"""Tests for the card-plate 3D (GLB) renderer."""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import pytest
+
+from ceq_api.render.renderers import registry
+from ceq_api.render.renderers.card_plate_3d import CardPlateRenderer
+
+# ---------- registry ----------
+
+
+def test_card_plate_registered() -> None:
+    r = registry.get("card-plate")
+    assert r.template == "card-plate"
+    assert r.content_type == "model/gltf-binary"
+    assert r.extension == "glb"
+
+
+# ---------- GLB structural correctness ----------
+
+
+def test_card_plate_produces_glb_with_correct_magic() -> None:
+    out = CardPlateRenderer().render({})
+    # GLB magic: "glTF" (0x46546C67 little-endian).
+    assert out[:4] == b"glTF"
+    version = struct.unpack("<I", out[4:8])[0]
+    assert version == 2
+
+
+def test_card_plate_glb_length_field_matches_actual_size() -> None:
+    out = CardPlateRenderer().render({})
+    reported_length = struct.unpack("<I", out[8:12])[0]
+    assert reported_length == len(out)
+
+
+def test_card_plate_has_json_and_bin_chunks() -> None:
+    out = CardPlateRenderer().render({})
+    # After 12-byte header: JSON chunk header.
+    json_length, json_type = struct.unpack("<II", out[12:20])
+    assert json_type == 0x4E4F534A  # "JSON"
+    json_blob = out[20 : 20 + json_length]
+    # Strip trailing padding spaces.
+    gltf = json.loads(json_blob.rstrip(b" "))
+    assert gltf["asset"]["version"] == "2.0"
+    assert len(gltf["meshes"]) == 1
+    assert len(gltf["materials"]) == 1
+
+    # BIN chunk follows.
+    bin_header_offset = 20 + json_length
+    bin_length, bin_type = struct.unpack(
+        "<II", out[bin_header_offset : bin_header_offset + 8]
+    )
+    assert bin_type == 0x004E4942  # "BIN\0"
+    assert bin_length > 0
+
+
+def test_card_plate_mesh_is_non_empty() -> None:
+    out = CardPlateRenderer().render({})
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    # Position accessor must have a nontrivial count.
+    position_accessor = gltf["accessors"][gltf["meshes"][0]["primitives"][0]["attributes"]["POSITION"]]
+    assert position_accessor["count"] > 8  # at minimum more than a cube's 8 vertices
+    # Indexed triangle mesh — indices must be divisible by 3.
+    index_accessor_idx = gltf["meshes"][0]["primitives"][0]["indices"]
+    index_accessor = gltf["accessors"][index_accessor_idx]
+    assert index_accessor["count"] > 0
+    assert index_accessor["count"] % 3 == 0
+
+
+def test_card_plate_bounding_box_matches_dimensions() -> None:
+    """Position accessor min/max should match width/height/thickness inputs."""
+    data = {"width_mm": 60.0, "height_mm": 90.0, "thickness_mm": 3.0, "corner_radius_mm": 5.0}
+    out = CardPlateRenderer().render(data)
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    pos_accessor = gltf["accessors"][0]
+    assert pos_accessor["min"] == [-30.0, -45.0, -1.5]
+    assert pos_accessor["max"] == [30.0, 45.0, 1.5]
+
+
+# ---------- determinism ----------
+
+
+def test_card_plate_is_deterministic() -> None:
+    r = CardPlateRenderer()
+    data = {
+        "width_mm": 63.5,
+        "height_mm": 88.9,
+        "thickness_mm": 2.0,
+        "corner_radius_mm": 4.0,
+        "accent_hex": "#3C8CFF",
+    }
+    assert r.render(data) == r.render(data)
+
+
+def test_card_plate_different_dimensions_produce_different_bytes() -> None:
+    r = CardPlateRenderer()
+    small = r.render({"width_mm": 50.0, "height_mm": 70.0})
+    large = r.render({"width_mm": 80.0, "height_mm": 110.0})
+    assert small != large
+
+
+def test_card_plate_different_accent_produces_different_bytes() -> None:
+    r = CardPlateRenderer()
+    blue = r.render({"accent_hex": "#3C8CFF"})
+    red = r.render({"accent_hex": "#FF5A3C"})
+    assert blue != red
+
+
+# ---------- parameter clamping / validation ----------
+
+
+def test_card_plate_clamps_huge_dimensions() -> None:
+    r = CardPlateRenderer()
+    # width_mm=10000 should clamp to 300.
+    out = r.render({"width_mm": 10000.0, "height_mm": 10000.0})
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    pos_accessor = gltf["accessors"][0]
+    assert pos_accessor["max"][0] <= 150.0  # 300/2
+    assert pos_accessor["max"][1] <= 150.0
+
+
+def test_card_plate_clamps_tiny_thickness() -> None:
+    r = CardPlateRenderer()
+    # thickness_mm=0.01 should clamp to 0.5 minimum.
+    out = r.render({"thickness_mm": 0.01})
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    pos_accessor = gltf["accessors"][0]
+    assert pos_accessor["max"][2] >= 0.25  # half of 0.5mm minimum
+
+
+def test_card_plate_radius_exceeding_half_dim_is_reduced() -> None:
+    """Corner radius cannot exceed half the smaller dimension; reduce silently."""
+    r = CardPlateRenderer()
+    # 100mm wide, 50mm tall, radius=40 → would exceed 25 (half of 50), reduce to 25.
+    out = r.render({
+        "width_mm": 100.0,
+        "height_mm": 50.0,
+        "corner_radius_mm": 40.0,
+    })
+    # Should render without error and produce a closed mesh.
+    assert out[:4] == b"glTF"
+
+
+def test_card_plate_zero_radius_produces_sharp_corners() -> None:
+    r = CardPlateRenderer()
+    out = r.render({"corner_radius_mm": 0.0})
+    assert out[:4] == b"glTF"
+
+
+def test_card_plate_rejects_invalid_hex() -> None:
+    with pytest.raises(ValueError, match="hex"):
+        CardPlateRenderer().render({"accent_hex": "not-a-color"})
+
+
+def test_card_plate_defaults_work_without_any_input() -> None:
+    """Standard trading-card dimensions should be the default."""
+    out = CardPlateRenderer().render({})
+    assert out[:4] == b"glTF"
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    # Default is 63.5mm x 88.9mm (standard card).
+    pos_accessor = gltf["accessors"][0]
+    assert abs(pos_accessor["max"][0] - 31.75) < 0.01
+    assert abs(pos_accessor["max"][1] - 44.45) < 0.01
+
+
+def test_card_plate_material_uses_accent_color() -> None:
+    r = CardPlateRenderer()
+    # Pure red accent.
+    out = r.render({"accent_hex": "#FF0000"})
+    json_length = struct.unpack("<I", out[12:16])[0]
+    gltf = json.loads(out[20 : 20 + json_length].rstrip(b" "))
+    base_color = gltf["materials"][0]["pbrMetallicRoughness"]["baseColorFactor"]
+    assert base_color[0] == 1.0
+    assert base_color[1] == 0.0
+    assert base_color[2] == 0.0
+    assert base_color[3] == 1.0
+
+
+# ---------- endpoint integration ----------
+
+
+@pytest.fixture
+def render_storage(mock_storage):
+    from unittest.mock import AsyncMock
+
+    mock_storage.head_object = AsyncMock(return_value=False)
+    mock_storage.put_object = AsyncMock(return_value="r2://ceq-assets/render/card-plate/abc.glb")
+    mock_storage.storage_uri_for = lambda key: f"r2://ceq-assets/{key}"
+    mock_storage.get_public_url = lambda uri: f"https://cdn.ceq.lol/{uri.split('/', 3)[-1]}"
+    return mock_storage
+
+
+def test_render_3d_happy_path(client, render_storage) -> None:
+    resp = client.post(
+        "/v1/render/3d",
+        json={
+            "template": "card-plate",
+            "data": {"width_mm": 63.5, "height_mm": 88.9},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["template"] == "card-plate"
+    assert body["content_type"] == "model/gltf-binary"
+    assert body["cached"] is False
+    assert body["url"].endswith(".glb")
+    render_storage.put_object.assert_awaited_once()
+
+
+def test_render_3d_defaults_to_card_plate(client, render_storage) -> None:
+    resp = client.post("/v1/render/3d", json={"template": "", "data": {}})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["template"] == "card-plate"
+
+
+def test_render_3d_rejects_invalid_accent(client, render_storage) -> None:
+    resp = client.post(
+        "/v1/render/3d",
+        json={"template": "card-plate", "data": {"accent_hex": "not-hex"}},
+    )
+    assert resp.status_code == 422
+
+
+def test_render_3d_cache_hit_skips_upload(client, render_storage) -> None:
+    from unittest.mock import AsyncMock
+
+    render_storage.head_object = AsyncMock(return_value=True)
+    resp = client.post(
+        "/v1/render/3d",
+        json={"template": "card-plate", "data": {}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["cached"] is True
+    render_storage.put_object.assert_not_called()

--- a/apps/api/tests/test_audio_renderer.py
+++ b/apps/api/tests/test_audio_renderer.py
@@ -1,0 +1,196 @@
+"""Tests for the tone-beep audio renderer."""
+
+from __future__ import annotations
+
+import struct
+import wave
+from io import BytesIO
+
+import pytest
+
+from ceq_api.render.renderers import registry
+from ceq_api.render.renderers.audio_tone_beep import ToneBeepRenderer
+
+# ---------- registry ----------
+
+
+def test_tone_beep_registered() -> None:
+    r = registry.get("tone-beep")
+    assert r.template == "tone-beep"
+    assert r.content_type == "audio/wav"
+    assert r.extension == "wav"
+
+
+# ---------- WAV header / determinism ----------
+
+
+def test_tone_beep_produces_valid_wav_bytes() -> None:
+    out = ToneBeepRenderer().render({"frequency_hz": 440, "duration_ms": 100})
+    # RIFF container magic.
+    assert out[:4] == b"RIFF"
+    assert out[8:12] == b"WAVE"
+    assert len(out) > 100  # has actual audio data, not just a header
+
+
+def test_tone_beep_wav_fmt_chunk_correct() -> None:
+    out = ToneBeepRenderer().render({"frequency_hz": 440, "duration_ms": 50})
+    with wave.open(BytesIO(out), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getsampwidth() == 2  # 16-bit
+        assert wav.getframerate() == 22050
+        # 50ms @ 22.05kHz = ~1103 frames. Allow +/-1 for integer rounding.
+        assert abs(wav.getnframes() - 1102) <= 2
+
+
+def test_tone_beep_is_deterministic() -> None:
+    r = ToneBeepRenderer()
+    data = {"frequency_hz": 880, "duration_ms": 200, "envelope": "adsr-gentle", "volume": 0.5}
+    assert r.render(data) == r.render(data)
+
+
+def test_tone_beep_different_frequencies_produce_different_bytes() -> None:
+    r = ToneBeepRenderer()
+    a = r.render({"frequency_hz": 440, "duration_ms": 100})
+    b = r.render({"frequency_hz": 880, "duration_ms": 100})
+    assert a != b
+
+
+def test_tone_beep_different_durations_produce_different_lengths() -> None:
+    r = ToneBeepRenderer()
+    short = r.render({"frequency_hz": 440, "duration_ms": 50})
+    long = r.render({"frequency_hz": 440, "duration_ms": 500})
+    assert len(long) > len(short)
+
+
+# ---------- envelope differentiation ----------
+
+
+def test_tone_beep_envelopes_produce_different_bytes() -> None:
+    """Each envelope shape should produce distinct audio for the same tone."""
+    r = ToneBeepRenderer()
+    base = {"frequency_hz": 440, "duration_ms": 200, "volume": 0.8}
+    gentle = r.render({**base, "envelope": "adsr-gentle"})
+    sharp = r.render({**base, "envelope": "adsr-sharp"})
+    linear = r.render({**base, "envelope": "linear"})
+    square = r.render({**base, "envelope": "square"})
+    # All four should be mutually distinct (length identical, bytes differ).
+    assert gentle != sharp
+    assert gentle != linear
+    assert gentle != square
+    assert sharp != linear
+    assert sharp != square
+    assert linear != square
+
+
+def test_tone_beep_square_envelope_is_loudest_at_midpoint() -> None:
+    """Square envelope maintains full amplitude throughout — midpoint sample
+    should be larger than a gentle ADSR midpoint at same volume."""
+    r = ToneBeepRenderer()
+    # Use a very low frequency so the sine doesn't dominate at the midpoint sample.
+    square_out = r.render({"frequency_hz": 20, "duration_ms": 200, "envelope": "square", "volume": 1.0})
+    gentle_out = r.render({"frequency_hz": 20, "duration_ms": 200, "envelope": "adsr-gentle", "volume": 1.0})
+    # The two MUST differ — envelopes shape the amplitude differently.
+    assert square_out != gentle_out
+
+
+# ---------- parameter clamping / validation ----------
+
+
+def test_tone_beep_clamps_out_of_range_frequency() -> None:
+    r = ToneBeepRenderer()
+    # Below min (20Hz) and above max (20000Hz) should clamp, not error.
+    low = r.render({"frequency_hz": 1, "duration_ms": 50})
+    high = r.render({"frequency_hz": 99999, "duration_ms": 50})
+    assert low[:4] == b"RIFF"
+    assert high[:4] == b"RIFF"
+
+
+def test_tone_beep_clamps_out_of_range_duration() -> None:
+    r = ToneBeepRenderer()
+    # Should clamp to 10ms minimum, not produce an empty/invalid WAV.
+    short = r.render({"frequency_hz": 440, "duration_ms": 1})
+    with wave.open(BytesIO(short), "rb") as wav:
+        assert wav.getnframes() >= 1
+
+
+def test_tone_beep_clamps_volume_above_one() -> None:
+    """Volume > 1.0 should clamp to 1.0, not overflow int16 and produce garbage."""
+    r = ToneBeepRenderer()
+    out = r.render({"frequency_hz": 440, "duration_ms": 100, "volume": 999.0})
+    with wave.open(BytesIO(out), "rb") as wav:
+        frames = wav.readframes(wav.getnframes())
+    # No sample should exceed int16 max.
+    samples = struct.unpack(f"<{len(frames) // 2}h", frames)
+    assert max(samples) <= 32767
+    assert min(samples) >= -32768
+
+
+def test_tone_beep_rejects_invalid_envelope() -> None:
+    with pytest.raises(ValueError, match="envelope"):
+        ToneBeepRenderer().render({"envelope": "not-an-envelope"})
+
+
+def test_tone_beep_defaults_work_without_any_input() -> None:
+    """Calling with {} should yield the default 880Hz / 200ms beep."""
+    out = ToneBeepRenderer().render({})
+    assert out[:4] == b"RIFF"
+
+
+# ---------- endpoint integration ----------
+
+
+@pytest.fixture
+def render_storage(mock_storage):
+    from unittest.mock import AsyncMock
+
+    mock_storage.head_object = AsyncMock(return_value=False)
+    mock_storage.put_object = AsyncMock(return_value="r2://ceq-assets/render/tone-beep/abc.wav")
+    mock_storage.storage_uri_for = lambda key: f"r2://ceq-assets/{key}"
+    mock_storage.get_public_url = lambda uri: f"https://cdn.ceq.lol/{uri.split('/', 3)[-1]}"
+    return mock_storage
+
+
+def test_render_audio_happy_path(client, render_storage) -> None:
+    resp = client.post(
+        "/v1/render/audio",
+        json={
+            "template": "tone-beep",
+            "data": {"frequency_hz": 880, "duration_ms": 200},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["template"] == "tone-beep"
+    assert body["content_type"] == "audio/wav"
+    assert body["cached"] is False
+    assert body["url"].endswith(".wav")
+    render_storage.put_object.assert_awaited_once()
+
+
+def test_render_audio_defaults_to_tone_beep(client, render_storage) -> None:
+    """Empty template falls back to tone-beep so /v1/render/audio is still
+    useful without an explicit template name."""
+    resp = client.post("/v1/render/audio", json={"template": "", "data": {}})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["template"] == "tone-beep"
+
+
+def test_render_audio_rejects_invalid_envelope(client, render_storage) -> None:
+    resp = client.post(
+        "/v1/render/audio",
+        json={"template": "tone-beep", "data": {"envelope": "nonsense"}},
+    )
+    assert resp.status_code == 422
+
+
+def test_render_audio_cache_hit_skips_upload(client, render_storage) -> None:
+    from unittest.mock import AsyncMock
+
+    render_storage.head_object = AsyncMock(return_value=True)
+    resp = client.post(
+        "/v1/render/audio",
+        json={"template": "tone-beep", "data": {"frequency_hz": 440}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["cached"] is True
+    render_storage.put_object.assert_not_called()

--- a/apps/api/tests/test_render.py
+++ b/apps/api/tests/test_render.py
@@ -149,27 +149,33 @@ def test_render_rejects_invalid_data(client, render_storage) -> None:
     assert resp.status_code == 422
 
 
-def test_render_audio_returns_501(client, render_storage) -> None:
+def test_render_audio_unknown_template_returns_404(client, render_storage) -> None:
+    """/audio now ships with `tone-beep`; unknown templates 404 like other families."""
     resp = client.post(
         "/v1/render/audio",
-        json={"template": "any", "data": {}},
+        json={"template": "nope", "data": {}},
     )
-    assert resp.status_code == 501
+    assert resp.status_code == 404
 
 
-def test_render_3d_returns_501(client, render_storage) -> None:
+def test_render_3d_unknown_template_returns_404(client, render_storage) -> None:
+    """/3d now ships with `card-plate`; unknown templates 404 like other families."""
     resp = client.post(
         "/v1/render/3d",
-        json={"template": "any", "data": {}},
+        json={"template": "nope", "data": {}},
     )
-    assert resp.status_code == 501
+    assert resp.status_code == 404
 
 
 def test_list_templates(client, render_storage) -> None:
     resp = client.get("/v1/render/templates")
     assert resp.status_code == 200
     templates = resp.json()
-    assert any(t["name"] == "card-standard" for t in templates)
+    names = {t["name"] for t in templates}
+    # All three built-ins should be exposed: image, audio, 3D.
+    assert "card-standard" in names
+    assert "tone-beep" in names
+    assert "card-plate" in names
 
 
 def test_render_returns_500_when_r2_upload_fails(client, render_storage) -> None:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 Client SDK for [ceq.lol](https://ceq.lol) — MADFAM's generative asset platform.
 
-Render thumbnails, cards, and (soon) audio/3D assets with deterministic caching. Same inputs always produce the same URL, so it's safe to call on every record save.
+Render thumbnails, cards, audio beeps, and 3D plates with deterministic caching. Same inputs always produce the same URL, so it's safe to call on every record save.
 
 ## Install
 
@@ -73,18 +73,47 @@ const { url, cached } = await ceq.renderThumbnail({
 console.log(cached); // true after the first call with identical inputs
 ```
 
+### `renderAudio(data, { template? })`
+
+Render a deterministic audio asset (WAV). Default template is `tone-beep` — a parametric sine-wave beep with ADSR envelopes, useful for notification chimes and UI feedback sounds.
+
+```ts
+const { url } = await ceq.renderAudio({
+  frequency_hz: 880,
+  duration_ms: 200,
+  envelope: "adsr-gentle",
+  volume: 0.5,
+});
+// <audio src={url} /> — same params → same URL → R2-cached forever.
+```
+
+### `render3D(data, { template? })`
+
+Render a deterministic 3D asset (GLB / glTF 2.0 binary). Default template is `card-plate` — a parametric rounded-rectangle plate sized to a standard trading card, suitable as an AR preview target or a physical-prototype reference.
+
+```ts
+const { url } = await ceq.render3D({
+  width_mm: 63.5,
+  height_mm: 88.9,
+  thickness_mm: 2.0,
+  corner_radius_mm: 4.0,
+  accent_hex: "#3C8CFF",
+});
+// Drop `url` into your <model-viewer src={url}> element.
+```
+
 ### `listTemplates()`
 
 Enumerate available templates + their current versions. Use this to discover what's available or pin to a specific version.
 
 ```ts
 const templates = await ceq.listTemplates();
-//=> [{ name: "card-standard", version: "1", content_type: "image/png", extension: "png" }]
+// => [
+//   { name: "card-plate", version: "1", content_type: "model/gltf-binary", extension: "glb" },
+//   { name: "card-standard", version: "1", content_type: "image/png", extension: "png" },
+//   { name: "tone-beep", version: "1", content_type: "audio/wav", extension: "wav" },
+// ]
 ```
-
-## Reserved endpoints (not yet implemented)
-
-The CEQ API also exposes `POST /v1/render/audio` and `POST /v1/render/3d` — both return **501** today with a stable request shape. This SDK does not yet wrap them (will land once the backends do). If you need to integrate early, call the endpoints directly with `fetch` + your bearer token; the response shape will match `RenderResponse` when ready.
 
 ## Error handling
 

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -53,6 +53,74 @@ describe("CeqClient", () => {
     expect(headers.authorization).toBe("Bearer t");
   });
 
+  it("renderAudio posts to /v1/render/audio with the tone-beep template", async () => {
+    const fetchImpl = mockFetch([
+      {
+        status: 200,
+        body: {
+          url: "https://cdn.ceq.lol/render/tone-beep/abc.wav",
+          storage_uri: "r2://ceq-assets/render/tone-beep/abc.wav",
+          hash: "abc",
+          template: "tone-beep",
+          template_version: "1",
+          content_type: "audio/wav",
+          cached: false,
+        },
+      },
+    ]);
+    const ceq = new CeqClient({ fetch: fetchImpl, token: "t" });
+
+    const result = await ceq.renderAudio({
+      frequency_hz: 880,
+      duration_ms: 200,
+      envelope: "adsr-gentle",
+    });
+
+    expect(result.content_type).toBe("audio/wav");
+    expect(result.template).toBe("tone-beep");
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]!;
+    expect(call[0]).toBe("https://api.ceq.lol/v1/render/audio");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.template).toBe("tone-beep");
+    expect(body.data.frequency_hz).toBe(880);
+    expect(body.data.envelope).toBe("adsr-gentle");
+  });
+
+  it("render3D posts to /v1/render/3d with the card-plate template", async () => {
+    const fetchImpl = mockFetch([
+      {
+        status: 200,
+        body: {
+          url: "https://cdn.ceq.lol/render/card-plate/abc.glb",
+          storage_uri: "r2://ceq-assets/render/card-plate/abc.glb",
+          hash: "abc",
+          template: "card-plate",
+          template_version: "1",
+          content_type: "model/gltf-binary",
+          cached: false,
+        },
+      },
+    ]);
+    const ceq = new CeqClient({ fetch: fetchImpl, token: "t" });
+
+    const result = await ceq.render3D({
+      width_mm: 63.5,
+      height_mm: 88.9,
+      accent_hex: "#3C8CFF",
+    });
+
+    expect(result.content_type).toBe("model/gltf-binary");
+    expect(result.template).toBe("card-plate");
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]!;
+    expect(call[0]).toBe("https://api.ceq.lol/v1/render/3d");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.template).toBe("card-plate");
+    expect(body.data.width_mm).toBe(63.5);
+    expect(body.data.accent_hex).toBe("#3C8CFF");
+  });
+
   it("throws CeqApiError with detail on non-2xx", async () => {
     const fetchImpl = mockFetch([
       { status: 404, body: { detail: "unknown template: 'nope'" } },

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,9 +1,11 @@
 import {
   CardData,
+  CardPlateData,
   CeqApiError,
   RenderRequest,
   RenderResponse,
   TemplateInfo,
+  ToneBeepData,
 } from "./types.js";
 
 export interface CeqClientOptions {
@@ -88,6 +90,37 @@ export class CeqClient {
     request: RenderRequest<TData>
   ): Promise<RenderResponse> {
     return this.post<RenderResponse>("/v1/render/thumbnail", request);
+  }
+
+  /**
+   * Render a deterministic audio asset (WAV). Defaults to the `tone-beep`
+   * template — a parametric sine-wave beep with ADSR envelopes, useful for
+   * notification chimes and UI feedback sounds. Same input → same URL.
+   */
+  async renderAudio(
+    data: ToneBeepData,
+    opts: { template?: string } = {}
+  ): Promise<RenderResponse> {
+    return this.post<RenderResponse>("/v1/render/audio", {
+      template: opts.template ?? "tone-beep",
+      data: data as unknown as Record<string, unknown>,
+    });
+  }
+
+  /**
+   * Render a deterministic 3D asset (GLB / glTF 2.0 binary). Defaults to the
+   * `card-plate` template — a parametric rounded-rectangle plate sized to a
+   * standard trading card. Same input → same URL. Useful for AR previews and
+   * physical-prototype targets.
+   */
+  async render3D(
+    data: CardPlateData,
+    opts: { template?: string } = {}
+  ): Promise<RenderResponse> {
+    return this.post<RenderResponse>("/v1/render/3d", {
+      template: opts.template ?? "card-plate",
+      data: data as unknown as Record<string, unknown>,
+    });
   }
 
   /** List available render templates. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,7 +3,9 @@ export type { CeqClientOptions } from "./client.js";
 export { CeqApiError } from "./types.js";
 export type {
   CardData,
+  CardPlateData,
   RenderRequest,
   RenderResponse,
   TemplateInfo,
+  ToneBeepData,
 } from "./types.js";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,3 +1,29 @@
+/** Tone-beep audio template input. All fields optional — defaults produce an 880Hz / 200ms gentle chime. */
+export interface ToneBeepData {
+  /** Sine wave frequency in Hz. Clamped to [20, 20000]. Default 880. */
+  frequency_hz?: number;
+  /** Tone duration in milliseconds. Clamped to [10, 5000]. Default 200. */
+  duration_ms?: number;
+  /** Amplitude envelope shape. Default "adsr-gentle". */
+  envelope?: "adsr-gentle" | "adsr-sharp" | "linear" | "square";
+  /** Peak amplitude in [0.0, 1.0]. Default 0.5. */
+  volume?: number;
+}
+
+/** Card-plate 3D template input. Dimensions in millimeters. All fields optional — defaults are standard trading-card dimensions. */
+export interface CardPlateData {
+  /** Plate width in mm. Clamped to [10, 300]. Default 63.5 (standard card). */
+  width_mm?: number;
+  /** Plate height in mm. Clamped to [10, 300]. Default 88.9 (standard card). */
+  height_mm?: number;
+  /** Plate thickness in mm. Clamped to [0.5, 20]. Default 2.0. */
+  thickness_mm?: number;
+  /** Corner radius in mm. Clamped to [0, 20]; further reduced to min(width,height)/2. Default 4.0. */
+  corner_radius_mm?: number;
+  /** PBR baseColorFactor as hex (#RRGGBB or #RGB). Default "#3C8CFF". */
+  accent_hex?: string;
+}
+
 /** Card template input. All fields except `title` are optional. */
 export interface CardData {
   /** Card title — required. Rendered large at the top. */


### PR DESCRIPTION
## Summary

Replaces `/v1/render/audio` and `/v1/render/3d` 501 stubs with working
deterministic implementations. Identical inputs → identical R2 URLs, same
hash+cache pipeline as the card renderer.

- **`tone-beep`** (audio/wav): stdlib WAV synthesis — 16-bit PCM @ 22.05kHz mono, 4 envelopes (adsr-gentle/sharp, linear, square). Good for notification chimes and UI feedback.
- **`card-plate`** (model/gltf-binary): hand-rolled GLB writer — parametric rounded-rectangle extrusion with PBR material. Defaults to standard trading-card dimensions (63.5×88.9×2mm).

Zero new dependencies — both renderers use only the Python stdlib (`wave`, `math`, `struct`, `json`). Router's `_render_image` dispatcher renamed to `_render_asset` since it's media-agnostic.

## Design choices

- **Hand-rolled GLB over pygltflib**: mesh is simple extrusion; adding a dep for ~150 lines of struct packing wasn't worth it, and it keeps the stdlib-leaning feel of the card renderer.
- **Defaults on /audio and /3d**: empty template falls back to `tone-beep` / `card-plate` respectively, so callers get something useful without reading docs first.
- **Parameter clamping over 422**: out-of-range numbers (volume=999, width=10000) clamp to valid range rather than error; invalid enums (envelope) and invalid hex still raise 422.

## Test plan

- [x] 17 audio tests + 20 3D tests covering determinism, param clamping, WAV header / GLB magic, envelope differentiation, bounding box math, material color
- [x] 22 existing render tests still pass (2 updated: 501 → 404 for unknown templates)
- [x] 2 new SDK tests for `renderAudio` / `render3D`; 8 existing pass
- [x] `ruff check` clean on all new files
- [x] Full API suite: 271/272 (1 pre-existing health-endpoint failure on main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)