### PR TITLE
security(dockerfile): add USER ceq to worker production image [AUDIT I.1]

### DIFF
--- a/apps/workers/Dockerfile
+++ b/apps/workers/Dockerfile
@@ -134,6 +134,15 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 # Volume mounts for models and outputs
 VOLUME ["/opt/models", "/opt/outputs"]
 
+# Audit 2026-04-23 (cross-cutting I.1): run as the non-root `ceq` user
+# created in the base stage. ComfyUI + CUDA both work as non-root when
+# the nvidia-container-toolkit maps `/dev/nvidia*` with the right group;
+# GPU-enabled K8s nodes already handle this via the nvidia device plugin.
+# If a deployment target still requires root (e.g. a Vast.ai image with
+# broken device permissions), override at runtime with `--user 0`.
+RUN chown -R ceq:ceq /opt/models /opt/outputs /opt/cache /opt/comfyui /app/ceq-worker
+USER ceq
+
 # Default command: Run queue consumer
 CMD ["python", "-m", "ceq_worker.queue"]
 


### PR DESCRIPTION
Audit 2026-04-23 cross-cutting I.1. `apps/workers/Dockerfile` created
a non-root `ceq` user in the base stage (line 44) but never switched
to it, so the production image ran as root. That trips Kyverno's
restricted pod-security policies and widens the blast radius of any
ComfyUI process escape.

Added `chown -R ceq:ceq` over the runtime paths + `USER ceq` right
before CMD. ComfyUI and CUDA both run fine as non-root on
nvidia-container-toolkit-managed GPU nodes (standard in our k3s
cluster). If a Vast.ai image needs root for some reason, override
with `--user 0` at runtime.

## Test plan
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
