### PR TITLE
security(dockerfile): add USER ceq to slim worker image [AUDIT I.1]

### DIFF
--- a/apps/workers/Dockerfile.slim
+++ b/apps/workers/Dockerfile.slim
@@ -75,4 +75,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 
 VOLUME ["/opt/models", "/opt/outputs"]
 
+
+# Audit 2026-04-23 (cross-cutting I.1): run as non-root `ceq`.
+# ComfyUI + CUDA both work as non-root on nvidia-container-toolkit-managed
+# GPU nodes (standard in our k3s cluster). Override with `--user 0` at
+# runtime if a Vast.ai target needs root.
+RUN useradd -r -u 10001 -m -s /bin/bash ceq \
+    && chown -R ceq:ceq /opt/comfyui /opt/models /opt/outputs /opt/cache /app/ceq-worker
+USER ceq
+
 CMD ["python", "-m", "ceq_worker.queue"]


### PR DESCRIPTION
Audit 2026-04-23 cross-cutting I.1. `apps/workers/Dockerfile.slim` had no
USER directive — ran as root on `nvidia/cuda:12.4.0-runtime-ubuntu22.04`.

Unlike `Dockerfile` (prod), the slim variant doesn't create a user in an
earlier stage, so this PR adds `useradd -r -u 10001 ceq` along with the
chown of ComfyUI/models/outputs/cache runtime paths and `USER ceq` right
before CMD. Matches the semantics of PR #7 which shipped for the prod
Dockerfile in this same batch.

## Test plan
- [ ] Build the image and verify it boots as UID != 0 (`docker run ... id -u`).
- [ ] CI green on the branch.
- [ ] Review audit anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` §I.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
