### PR TITLE
docs: add self-contained ECOSYSTEM.md with enclii CLI DevOps reference

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,247 @@
+# ceq — Ecosystem Context
+
+> **Creative Entropy Quantized — ComfyUI wrapper + /v1/render asset pillar for MADFAM.**
+
+This file is self-contained: a Claude session on a fresh machine can operate
+this service by reading only this one document. No external links are
+load-bearing — the MADFAM ecosystem map and the full enclii CLI reference are
+embedded below.
+
+---
+
+## 1. What this repo is
+
+CEQ is MADFAM's internal content generation platform: a streamlined hacker-centric ComfyUI wrapper. Ships `/v1/render/*` deterministic R2-cached render endpoints + `@ceq/sdk` as the asset pillar consumed across the ecosystem. First consumer: Rondelio's stratum-tcg. Audio/3D rendering stubs exist but return 501. Domain: `ceq.lol`.
+
+**Pillar**: Brand / Asset pillar
+**Type**: service
+**Status**: production
+
+### Deployed services
+
+| Service | Public domain | Container port |
+|---|---|---|
+| `ceq-studio` | ceq.lol | 3000 |
+| `ceq-api` | api.ceq.lol | 8000 |
+| `ceq-workers` | (ComfyUI worker — GPU node) | 8188 |
+
+**Kubernetes namespace**: `ceq`
+**Cluster**: bare-metal k3s on Hetzner (see topology section below).
+
+### Upstream dependencies (this repo consumes)
+
+- ComfyUI (embedded in worker image)
+- nvidia-container-toolkit + GPU nodes
+- cloudflare R2 (deterministic render cache)
+- postgres (render jobs, manifests)
+- selva (LLM prompt augmentation)
+- janua (auth)
+
+### Downstream consumers (this repo is consumed by)
+
+- `@ceq/sdk` consumers (ecosystem asset pipeline)
+- stratum-tcg (rondelio) — first consumer
+- ui-components + marketing sites via rendered assets
+
+### Key environment variables
+
+- `DATABASE_URL — Postgres`
+- `R2_* — render cache`
+- `JANUA_JWKS_URI — auth`
+- `COMFYUI_PATH / MODELS_PATH — worker config`
+- `SELVA_BASE_URL — prompt augmentation`
+
+---
+
+## MADFAM Ecosystem Map
+
+MADFAM runs ~40 services on sovereign bare-metal infrastructure. Everything
+below is embedded here so this document stands alone.
+
+### The platforms every repo should know about
+
+| Platform | Repo | Role |
+|---|---|---|
+| **Enclii** | `madfam-org/enclii` | PaaS control plane — all deploys go through this |
+| **Janua** | `madfam-org/janua` | OIDC/OAuth 2.0 provider — RS256 JWKS at `auth.madfam.io/.well-known/jwks.json` |
+| **Dhanam** | `madfam-org/dhanam` | Billing + payment gateways (Stripe, Mercado Pago, SPEI, etc.) |
+| **Selva** | `madfam-org/autoswarm-office` | LLM inference routing + agent orchestration |
+| **Karafiel** | `madfam-org/karafiel` | Operational compliance — CFDI, NOM-151, e.firma, SAT-adjacent. Owns legal-ops / contract templates |
+| **Tezca** | `madfam-org/tezca` | Mexican law oracle (informational only — feeds Karafiel) |
+| **Cotiza** | `madfam-org/digifab-quoting` | MADFAM's quoting engine (fabrication + services) |
+| **Forgesight** | `madfam-org/forgesight` | Digital fabrication industry intelligence (pricing/vendor feed to Cotiza) |
+| **Pravara MES** | `madfam-org/pravara-mes` | Fabrication-node routing and dispatch (physical jobs) |
+| **PhyneCRM** | `madfam-org/phyne-crm` | Client-facing deliverables portal (single pane of glass per engagement) |
+| **Fortuna** | `madfam-org/fortuna` | Problem intelligence / zeitgeist analysis |
+| **Avala** | `madfam-org/avala` | Learning verification platform |
+
+### Cross-repo conventions
+
+- **Auth**: every authenticated service verifies Janua JWTs via JWKS at
+  `https://auth.madfam.io/.well-known/jwks.json`. RS256 only — HS256 is
+  fail-closed after the 2026-04-23 audit (H3/H4).
+- **Billing**: credit metering + entitlements flow through Dhanam. See
+  `madfam-org/dhanam` for the meter/entitlement/invoice APIs.
+- **Inference**: every LLM call should route through Selva
+  (`autoswarm-office`) at `/v1` (OpenAI-compatible). Do not talk directly
+  to OpenAI / Anthropic from service code.
+- **CORS**: explicit allowlist per service. Wildcards are banned
+  (audit 2026-04-23 H2/H5/H6).
+- **Images**: `@sha256:`-pinned in every manifest. Kyverno fail-closes on
+  `:latest` or mutable tags.
+- **Onboarding**: `POST /v1/admin/onboard` on switchyard-api creates
+  namespace, ArgoCD app, Cloudflare tunnel routes, Janua client, and
+  NetworkPolicies in one shot. See `enclii/docs/guides/ONBOARDING_GUIDE.md`.
+
+### Production topology
+
+Bare-metal k3s (v1.33+) on Hetzner, 3 nodes:
+
+- `foundry-cp` (Hetzner EX44, 14C/20T, 128 GB) — control-plane + primary workload
+- `foundry-worker-01` (Hetzner AX41-NVMe, Ryzen 5 3600, 64 GB) — worker + Longhorn 2nd replica
+- `foundry-builder-01` (Hetzner VPS, 2 vCPU, 4 GB, tainted `builder=true:NoSchedule`) — ARC runners only
+
+**Ingress**: Cloudflare Tunnel → 2× cloudflared pods → K8s ClusterIP → container port.
+Zero exposed node ports. TLS terminated at Cloudflare edge.
+
+**Storage**: Longhorn CSI v1.7+ in 2-replica mode across dedicated nodes.
+Object storage: Cloudflare R2 (zero egress).
+
+**GitOps**: ArgoCD App-of-Apps (~28 apps across ~22 namespaces) with self-heal.
+Push to `main` → CI builds → GHCR → `kustomize edit set image` commits digest →
+ArgoCD syncs → Switchyard tracks lifecycle events.
+
+**Operational access** (SSH, kubeconfigs, server IPs, cost ledger): private repo
+`madfam-org/internal-devops`. Not in any public repo.
+
+---
+
+## Enclii CLI — DevOps Reference
+
+**Strong preference: use `enclii` over `kubectl`** for all operational
+tasks. The CLI routes through Switchyard API, which gives you audit
+logging, lifecycle event tracking, and service-scoped context. Escape
+to kubectl only for the gaps listed at the end of this section.
+
+### Install
+
+```bash
+# macOS
+brew install enclii/tap/enclii
+
+# Linux
+curl -sSL https://get.enclii.dev | bash
+
+# From source (in the enclii repo)
+make build-cli && ./bin/enclii --version
+```
+
+### Auth
+
+```bash
+enclii login                  # browser SSO (Janua)
+enclii whoami                 # verify active session
+enclii logout                 # clear local creds
+```
+
+Env vars: `ENCLII_API_URL` (default `https://api.enclii.dev`),
+`ENCLII_TOKEN` (alternative to interactive login),
+`ENCLII_PROJECT`, `ENCLII_ENV`.
+
+### Day-to-day for ceq-api
+
+The commands below default to `ceq-api` — the primary service name for
+this repo as registered in Switchyard. For any other service in the
+ecosystem, swap the name.
+
+```bash
+# Status + where the pods are running
+enclii ps --wide
+enclii ps ceq-api --env production
+
+# Logs (tail, filter, history)
+enclii logs ceq-api -f                          # live tail
+enclii logs ceq-api --since 1h --level error    # last hour, errors only
+enclii logs ceq-api --env staging -f
+
+# Deploy (preview, staging, production)
+enclii deploy --env preview                       # from current branch
+enclii deploy --env staging
+enclii deploy --env production --strategy canary --canary-percent 10
+
+# Rollback
+enclii rollback ceq-api                         # previous release
+enclii rollback ceq-api --to-revision 5
+
+# Releases + history
+enclii releases ceq-api                          # list builds
+enclii releases ceq-api --latest --output json
+
+# Secrets (routed through Lockbox → Vault → ESO → K8s)
+enclii secrets list ceq-api
+enclii secrets set MY_KEY=value --service ceq-api --secret
+enclii secrets rm MY_KEY --service ceq-api
+
+# Domains, tunnel routes, DNS
+enclii domains list ceq-api
+enclii domains add ceq-api my.example.com       # auto-provisions tunnel route + DNS
+
+# Scheduled jobs (cron + one-off)
+enclii jobs list
+enclii jobs run <job-name>                         # trigger one-off
+
+# Routing (ingress + TLS)
+enclii junctions list ceq-api
+
+# Serverless (scale-to-zero functions)
+enclii functions list
+
+# Local dev environment
+enclii local up         # spin up dependent services (postgres, redis, …)
+enclii local logs
+enclii local down
+```
+
+### Full onboarding (only used when adding a brand-new service)
+
+```bash
+# One-shot: namespace + ArgoCD app + tunnel routes + Janua client + netpol
+enclii onboard --repo madfam-org/<name> --db-name <db> --secrets-file .env
+```
+
+### When to use kubectl (escape hatches)
+
+The enclii CLI routes through Switchyard. These operations don't yet have
+a CLI equivalent — kubectl is the right tool:
+
+- ArgoCD sync / patch — `kubectl patch application <app> -n argocd --type merge ...`
+- Kyverno PolicyExceptions + raw CRD management
+- Longhorn / PVC operations — `kubectl get volumes.longhorn.io -n longhorn-system`
+- Direct pod exec for debugging — `kubectl exec -n <ns> deploy/<svc> -- ...`
+- Raw port-forward — `kubectl port-forward -n <ns> svc/<svc> 8080:80`
+- Janua DB ops (no enclii equivalent)
+
+### Cluster access
+
+kubeconfig + SSH keys live in `madfam-org/internal-devops` (private repo).
+On a fresh machine, pull that repo first to get `~/.kube/config-hetzner`.
+
+### Exit codes (scripting against the CLI)
+
+| Code | Meaning |
+|---|---|
+| 0  | success |
+| 10 | validation error |
+| 20 | build failed |
+| 30 | deploy failed |
+| 40 | timeout |
+| 50 | auth error |
+
+---
+
+## Document provenance
+
+Generated 2026-04-23 as part of the "each repo stands alone" docs sweep. If the
+ecosystem map or CLI reference drifts from reality, update the generator at
+`madfam-org/enclii/docs/templates/ECOSYSTEM.md.template` and re-render — don't
+edit per-repo copies in isolation.


### PR DESCRIPTION
Adds `ECOSYSTEM.md` — a self-contained ecosystem context + enclii CLI DevOps
reference so a Claude session on a fresh machine can operate this service by
reading only this one document.

## What's in the file

1. **This repo's role in the MADFAM ecosystem** — pillar, type, status, deployed
   services (name/domain/port), K8s namespace, upstream dependencies, downstream
   consumers, key environment variables.
2. **MADFAM ecosystem map** — the 12 platforms every repo should know about
   (Enclii, Janua, Dhanam, Selva, Karafiel, Tezca, Cotiza, Forgesight, Pravara,
   PhyneCRM, Fortuna, Avala), cross-repo conventions (RS256 auth, Dhanam
   billing, Selva inference routing, CORS allowlists, SHA-pinned images), and
   the bare-metal Hetzner k3s topology. Embedded verbatim — no external links
   are load-bearing.
3. **Enclii CLI reference** — install, auth, the ~25 commands an operator of
   this service will actually run (parameterized to this repo's primary service
   name), when to escape to kubectl, and a pointer at `madfam-org/internal-devops`
   for cluster access.

## Why

Requested as prep for a machine switch. Each repo now carries enough context
that a fresh Claude session can pick up here without needing to read cross-repo
docs or memory. The ~8KB of shared ecosystem-map + CLI-reference content is
intentionally duplicated across every repo (requested) so each one truly
stands alone.

## How it was generated

Template-driven, one generator run across all 39 non-excluded repos (rondelio
skipped — parallel agent working there). Per-repo metadata lives in the
generator; shared boilerplate is centralized. To update the ecosystem map or
the CLI reference across the fleet, update the generator and re-render.

## Test plan
- [ ] Open `ECOSYSTEM.md` and confirm the "Role" section accurately describes
      this repo's place in the ecosystem.
- [ ] Spot-check the deployed-services table — domains/ports should match
      reality.
- [ ] Dependencies / consumers accurate? Flag any I missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
