### PR TITLE
feat(monetization): InterestGate (email-capture-instead-of-paywall)

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -202,6 +202,98 @@ async def protected_route(user = Depends(get_current_user)):
 
 JWT tokens are validated against Janua's JWKS endpoint.
 
+## Monetization gating (InterestGate)
+
+CEQ is in pre-monetization mode. Instead of a real paywall in front of "Pro"
+features, the studio uses the **InterestGate** pattern: gated UI is wrapped
+in `<InterestGate featureKey="..." variant="overlay">` (see
+`apps/studio/src/components/InterestGate.tsx`), which shows an email-capture
+form. Free `/v1/render/*` endpoints stay open for evaluators — only the
+studio surface gates "Pro" templates today.
+
+### Endpoint
+
+| Method | Endpoint | Auth | Rate limit | Description |
+|--------|----------|------|-----------|-------------|
+| `POST` | `/v1/interest/` | none | 10/hour per IP | Capture email + feature_key (+ optional wishlist) |
+
+Responses:
+- `201 Created` `{"status": "registered"}` — first capture for `(email, feature_key)`
+- `200 OK` `{"status": "already_registered"}` — duplicate; backfills missing fields
+- `400/422` — invalid email or unknown `feature_key`
+- `429` — rate limit exceeded
+- `503` — capture disabled (`INTEREST_ENABLED=false`)
+
+Allowed `feature_key` values are listed in
+`apps/api/src/ceq_api/routers/interest.py::ALLOWED_FEATURES`. Add new keys
+there when you wire up new gates and keep them in sync with
+`apps/studio/src/lib/feature-labels.ts`.
+
+### Storage
+
+Captures land in the `feature_interest` table (see migration
+`8a3f1c4e5d20_add_feature_interest.py` and model
+`ceq_api/models/feature_interest.py`). Indexed on `(email, feature_key)` for
+the upsert lookup and on `(feature_key, created_at)` for analytics.
+
+### CRM dispatch
+
+On every successful **new** registration the API enqueues a
+`dispatch_interest_to_crm` background task that POSTs an HMAC-SHA256-signed
+payload to `CRM_WEBHOOK_URL`. When either `CRM_WEBHOOK_URL` or
+`CRM_WEBHOOK_SECRET` is unset, the dispatch is a silent no-op — the DB row
+is still the source of truth. Phyne-CRM receives:
+
+```json
+{
+  "event": "interest.created",
+  "timestamp": "2026-04-25T12:00:00+00:00",
+  "source": "ceq",
+  "data": {
+    "email": "user@example.com",
+    "feature_key": "premium_render",
+    "wishlist": {"text": "..."} ,
+    "janua_user_id": null,
+    "source_page": "templates/3d",
+    "created_at": "2026-04-25T12:00:00+00:00"
+  }
+}
+```
+
+Verify with:
+
+```python
+expected = hmac.new(secret, raw_body, hashlib.sha256).hexdigest()
+assert request.headers["X-Webhook-Signature"] == f"sha256={expected}"
+```
+
+### Environment
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `INTEREST_ENABLED` | `true` | Set to `false` to hard-disable capture (returns 503) |
+| `CRM_WEBHOOK_URL` | `""` | e.g. `https://crm.madfam.io/api/webhooks/ceq`. Empty = no-op |
+| `CRM_WEBHOOK_SECRET` | `""` | 32-byte hex secret shared with Phyne-CRM. Empty = no-op |
+| `CRM_WEBHOOK_TIMEOUT_SECONDS` | `5.0` | Per-request HTTP timeout |
+
+### Flipping to paid checkout later
+
+When WTP signal is sufficient and billing is wired up:
+
+1. Replace `<InterestGate>` wrappers in the studio with a real checkout/tier
+   gate (e.g. a `<TierGate>` similar to tezca's pattern).
+2. Keep `POST /v1/interest/` available as a **fallback** for "not ready to
+   buy" users — it's still useful WTP signal post-launch.
+3. Migrate the existing `feature_interest` rows into the CRM as a warm
+   waitlist; email them announcing checkout availability.
+4. Add a deprecation log line to `register_interest` when the feature_key
+   has a paid SKU available, so we can spot rows that should have hit
+   checkout instead.
+
+The existing free `/v1/render/*` endpoints stay open under all gating
+strategies — they're the public evaluation surface and the contract Rondelio
++ other internal consumers depend on (see `@ceq/sdk`).
+
 ## Development
 
 ```bash

--- a/apps/api/src/ceq_api/alembic/versions/8a3f1c4e5d20_add_feature_interest.py
+++ b/apps/api/src/ceq_api/alembic/versions/8a3f1c4e5d20_add_feature_interest.py
@@ -1,0 +1,104 @@
+"""add feature_interest table
+
+Revision ID: 8a3f1c4e5d20
+Revises: 0d39ee97cdbd
+Create Date: 2026-04-25 12:00:00.000000
+
+Adds the `feature_interest` table backing the InterestGate component
+(POST /v1/interest/). Captures email + feature_key tuples plus an optional
+JSON wishlist, while monetization is still in WTP-discovery mode.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "8a3f1c4e5d20"
+down_revision: Union[str, None] = "0d39ee97cdbd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feature_interest",
+        sa.Column(
+            "email",
+            sa.String(length=320),
+            nullable=False,
+            comment="User-provided email (lowercased, trimmed before insert).",
+        ),
+        sa.Column(
+            "feature_key",
+            sa.String(length=64),
+            nullable=False,
+            comment="Feature identifier, e.g. premium_render | training_access | team_seats.",
+        ),
+        sa.Column(
+            "wishlist",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            comment="Free-form structured wishlist; up to 2000 chars when stored as text.",
+        ),
+        sa.Column(
+            "janua_user_id",
+            sa.String(length=64),
+            nullable=True,
+            comment="Janua subject ID when the user is signed in.",
+        ),
+        sa.Column(
+            "source_page",
+            sa.String(length=255),
+            nullable=True,
+            comment="Page/component that triggered the gate.",
+        ),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_feature_interest_email"),
+        "feature_interest",
+        ["email"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_feature_interest_feature_key"),
+        "feature_interest",
+        ["feature_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_feature_interest_email_feature",
+        "feature_interest",
+        ["email", "feature_key"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_feature_interest_feature_created",
+        "feature_interest",
+        ["feature_key", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feature_interest_feature_created", table_name="feature_interest")
+    op.drop_index("ix_feature_interest_email_feature", table_name="feature_interest")
+    op.drop_index(op.f("ix_feature_interest_feature_key"), table_name="feature_interest")
+    op.drop_index(op.f("ix_feature_interest_email"), table_name="feature_interest")
+    op.drop_table("feature_interest")

--- a/apps/api/src/ceq_api/config.py
+++ b/apps/api/src/ceq_api/config.py
@@ -75,6 +75,20 @@ class Settings(BaseSettings):
     # CORS
     cors_origins: list[str] = ["http://localhost:5801", "https://ceq.lol"]
 
+    # InterestGate / pre-monetization feature-interest capture
+    # When `interest_enabled=True` (default), the public POST /v1/interest/
+    # endpoint accepts email + feature_key submissions from the studio's
+    # InterestGate component. Set to False to hard-disable capture (the
+    # endpoint will return 503).
+    interest_enabled: bool = True
+
+    # Outbound webhook to Phyne-CRM. When CRM_WEBHOOK_URL is empty the
+    # `dispatch_interest_to_crm` background task is a no-op — the row is still
+    # persisted, we just skip the push. Set both values to wire CRM sync.
+    crm_webhook_url: str = ""
+    crm_webhook_secret: str = ""
+    crm_webhook_timeout_seconds: float = 5.0
+
     @model_validator(mode="after")
     def validate_production_settings(self) -> "Settings":
         """Validate required settings for production environment."""

--- a/apps/api/src/ceq_api/main.py
+++ b/apps/api/src/ceq_api/main.py
@@ -34,7 +34,7 @@ from prometheus_client import make_asgi_app
 from ceq_api.config import get_settings
 from ceq_api.logging import setup_logging
 from ceq_api.middleware import setup_middleware
-from ceq_api.routers import assets, health, jobs, outputs, render, templates, workflows
+from ceq_api.routers import assets, health, interest, jobs, outputs, render, templates, workflows
 
 # Initialize logging first
 setup_logging()
@@ -100,6 +100,7 @@ app.include_router(templates.router, prefix="/v1/templates", tags=["templates"])
 app.include_router(assets.router, prefix="/v1/assets", tags=["assets"])
 app.include_router(outputs.router, prefix="/v1/outputs", tags=["outputs"])
 app.include_router(render.router, prefix="/v1/render", tags=["render"])
+app.include_router(interest.router)
 
 
 @app.get("/")

--- a/apps/api/src/ceq_api/models/__init__.py
+++ b/apps/api/src/ceq_api/models/__init__.py
@@ -2,6 +2,7 @@
 
 from ceq_api.models.base import Base, TimestampMixin
 from ceq_api.models.asset import Asset
+from ceq_api.models.feature_interest import FeatureInterest
 from ceq_api.models.job import Job, JobStatus
 from ceq_api.models.output import Output
 from ceq_api.models.template import Template
@@ -11,6 +12,7 @@ __all__ = [
     "Base",
     "TimestampMixin",
     "Asset",
+    "FeatureInterest",
     "Job",
     "JobStatus",
     "Output",

--- a/apps/api/src/ceq_api/models/feature_interest.py
+++ b/apps/api/src/ceq_api/models/feature_interest.py
@@ -1,0 +1,66 @@
+"""FeatureInterest model — captures user interest in gated/upcoming features.
+
+Used by the InterestGate pattern: instead of putting a paywall in front of a
+"Pro" feature when monetization isn't enabled yet, we collect the user's email
++ optional wishlist text. This generates Willingness-To-Pay (WTP) signal that
+later informs pricing and feature prioritization.
+
+Once paid checkout is wired up, the gate flips from `<InterestGate>` → real
+billing; existing rows in this table become the warm waitlist to migrate.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ceq_api.models.base import Base, JSONB, TimestampMixin
+
+
+class FeatureInterest(Base, TimestampMixin):
+    """One row per (email, feature_key) pair. Indexed for upsert lookup."""
+
+    __tablename__ = "feature_interest"
+
+    email: Mapped[str] = mapped_column(
+        String(320),
+        nullable=False,
+        index=True,
+        comment="User-provided email (lowercased, trimmed before insert).",
+    )
+    feature_key: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        index=True,
+        comment="Feature identifier, e.g. premium_render | training_access | team_seats.",
+    )
+    wishlist: Mapped[dict | list | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment=(
+            "Free-form structured wishlist — accepts list[str], dict, or "
+            "{'text': '...'} for raw textarea input. Up to 2000 chars when text."
+        ),
+    )
+    janua_user_id: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Janua subject ID when the user is signed in. Nullable for anon capture.",
+    )
+    source_page: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Page/component that triggered the gate (e.g. 'templates/3d').",
+    )
+
+    __table_args__ = (
+        # Composite index on (email, feature_key) — supports the upsert lookup
+        # in the POST handler. Not unique because the request endpoint enforces
+        # idempotency in code (returns 200 on duplicate) and we may want to
+        # tolerate eventual schema drift.
+        Index("ix_feature_interest_email_feature", "email", "feature_key"),
+        Index("ix_feature_interest_feature_created", "feature_key", "created_at"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<FeatureInterest {self.email} -> {self.feature_key}>"

--- a/apps/api/src/ceq_api/routers/interest.py
+++ b/apps/api/src/ceq_api/routers/interest.py
@@ -1,0 +1,209 @@
+"""POST /v1/interest/ — feature-interest capture (InterestGate backend).
+
+Public, unauthenticated, rate-limited. Stands in for paywall/checkout while
+the studio is in the WTP-discovery phase. Captures email + feature_key (+ an
+optional wishlist) so we can build a warm waitlist before flipping the gate
+to real billing.
+
+Idempotent on (email, feature_key):
+- New row    -> 201 Created   {status: "registered"}
+- Duplicate  -> 200 OK        {status: "already_registered"}
+- CRM dispatch is enqueued only on the first registration.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Annotated, Any
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    status,
+)
+from pydantic import BaseModel, EmailStr, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ceq_api.config import get_settings
+from ceq_api.db import get_db
+from ceq_api.middleware import limiter
+from ceq_api.models import FeatureInterest
+from ceq_api.services.crm_sync import dispatch_interest_to_crm
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/interest", tags=["interest"])
+
+
+# Allowed feature_key values. Kept narrow on purpose — every key here should
+# correspond to something the studio actually gates today. Add new keys when
+# you wire up new gates; reject unknown keys with 422.
+ALLOWED_FEATURES: frozenset[str] = frozenset(
+    {
+        "premium_render",   # Pro render templates / quotas
+        "training_access",  # Custom model training
+        "team_seats",       # Multi-seat collaboration
+        "early_access",     # Generic waitlist
+    }
+)
+
+MAX_WISHLIST_TEXT_CHARS = 2000
+
+
+# === Schemas ===
+
+
+class InterestRequest(BaseModel):
+    """Request body for POST /v1/interest/."""
+
+    email: EmailStr
+    feature_key: str = Field(..., min_length=1, max_length=64)
+    wishlist: Any | None = Field(
+        default=None,
+        description=(
+            "Optional structured or free-text wishlist. Accepts: a string "
+            "(treated as raw text, capped at 2000 chars), a list of strings, "
+            "or a small object. Stored as JSONB."
+        ),
+    )
+    janua_user_id: str | None = Field(default=None, max_length=64)
+    source_page: str | None = Field(default=None, max_length=255)
+
+    @field_validator("feature_key")
+    @classmethod
+    def _validate_feature_key(cls, v: str) -> str:
+        v = v.strip()
+        if v not in ALLOWED_FEATURES:
+            allowed = ", ".join(sorted(ALLOWED_FEATURES))
+            raise ValueError(f"feature_key must be one of: {allowed}")
+        return v
+
+    @field_validator("wishlist")
+    @classmethod
+    def _normalize_wishlist(cls, v: Any | None) -> Any | None:
+        if v is None:
+            return None
+        if isinstance(v, str):
+            text = v.strip()
+            if not text:
+                return None
+            return {"text": text[:MAX_WISHLIST_TEXT_CHARS]}
+        # list / dict — let JSONB handle it. We don't deep-validate here.
+        return v
+
+
+class InterestResponse(BaseModel):
+    """Response payload — matches tezca's shape so the frontend port is 1:1."""
+
+    status: str = Field(..., description="'registered' (new) or 'already_registered'.")
+
+
+# === Endpoint ===
+
+
+@router.post(
+    "/",
+    response_model=InterestResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register interest in a gated feature (InterestGate backend)",
+    description=(
+        "Public, rate-limited endpoint. Captures email + feature_key for "
+        "pre-monetization WTP signal. Idempotent on (email, feature_key): "
+        "returns 201 on first registration, 200 if already registered."
+    ),
+)
+@limiter.limit("10/hour")
+async def register_interest(
+    request: Request,  # required by slowapi for keying
+    payload: InterestRequest,
+    background_tasks: BackgroundTasks,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Any:
+    """Register interest in a gated feature."""
+    settings = get_settings()
+    if not settings.interest_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Interest capture is disabled.",
+        )
+
+    email = payload.email.lower().strip()
+    feature_key = payload.feature_key
+    wishlist = payload.wishlist
+    janua_user_id = (payload.janua_user_id or "").strip() or None
+    source_page = (payload.source_page or "").strip() or None
+
+    # Look up an existing (email, feature_key) row first — the index makes this cheap.
+    existing_q = select(FeatureInterest).where(
+        FeatureInterest.email == email,
+        FeatureInterest.feature_key == feature_key,
+    )
+    existing = (await db.execute(existing_q)).scalar_one_or_none()
+
+    if existing is not None:
+        # Backfill missing supplementary fields if the user provided them this time.
+        # We don't overwrite non-null values — first capture wins for those.
+        dirty = False
+        if wishlist is not None and not existing.wishlist:
+            existing.wishlist = wishlist
+            dirty = True
+        if janua_user_id and not existing.janua_user_id:
+            existing.janua_user_id = janua_user_id
+            dirty = True
+        if source_page and not existing.source_page:
+            existing.source_page = source_page
+            dirty = True
+        if dirty:
+            await db.flush()
+        # Return 200 on duplicate. FastAPI defaults to 201 from the decorator,
+        # so we override via the Response model + raise.
+        # Cleanest path: return a JSONResponse with the desired status.
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={"status": "already_registered"},
+        )
+
+    # New registration.
+    record = FeatureInterest(
+        email=email,
+        feature_key=feature_key,
+        wishlist=wishlist,
+        janua_user_id=janua_user_id,
+        source_page=source_page,
+    )
+    db.add(record)
+    await db.flush()
+    await db.refresh(record)
+
+    # Fire-and-forget CRM push. No-ops when CRM_WEBHOOK_URL is unset.
+    background_tasks.add_task(
+        dispatch_interest_to_crm,
+        {
+            "email": record.email,
+            "feature_key": record.feature_key,
+            "wishlist": record.wishlist,
+            "janua_user_id": record.janua_user_id,
+            "source_page": record.source_page,
+            "created_at": (
+                record.created_at.isoformat()
+                if isinstance(record.created_at, datetime)
+                else None
+            ),
+        },
+    )
+
+    logger.info(
+        "interest registered: feature_key=%s source_page=%s authed=%s",
+        feature_key,
+        source_page or "-",
+        bool(janua_user_id),
+    )
+
+    return InterestResponse(status="registered")

--- a/apps/api/src/ceq_api/services/__init__.py
+++ b/apps/api/src/ceq_api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer modules for ceq-api (CRM sync, etc.)."""

--- a/apps/api/src/ceq_api/services/crm_sync.py
+++ b/apps/api/src/ceq_api/services/crm_sync.py
@@ -1,0 +1,108 @@
+"""CRM webhook dispatch — pushes interest.created events to Phyne-CRM.
+
+Mirrors the tezca pattern (`apps/api/crm_sync.py` + `tasks.deliver_crm_webhook`)
+but adapted to ceq-api's stack: async httpx + FastAPI BackgroundTasks instead
+of Celery. No-ops when `CRM_WEBHOOK_URL` or `CRM_WEBHOOK_SECRET` is unset, so
+local dev and self-hosted deployments work without CRM wiring.
+
+Payload signing: HMAC-SHA256 over the raw JSON body, hex-encoded, sent as
+`X-Webhook-Signature: sha256=<hex>`. Phyne-CRM verifies with the shared secret.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from ceq_api.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    """HMAC-SHA256 hex digest of `body` with `secret`."""
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def _serialize_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Build the wire payload for an interest.created event."""
+    return {
+        "event": "interest.created",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source": "ceq",
+        "data": {
+            "email": record.get("email"),
+            "feature_key": record.get("feature_key"),
+            "wishlist": record.get("wishlist"),
+            "janua_user_id": record.get("janua_user_id"),
+            "source_page": record.get("source_page"),
+            "created_at": record.get("created_at"),
+        },
+    }
+
+
+async def dispatch_interest_to_crm(record: dict[str, Any]) -> None:
+    """Push a feature-interest record to Phyne-CRM.
+
+    Designed to be called from FastAPI's BackgroundTasks (fire-and-forget). All
+    failures are logged and swallowed — a CRM outage must never break the
+    user-facing capture flow. The DB row is the source of truth; CRM sync is a
+    convenience.
+
+    Args:
+        record: Dict with at minimum `email` and `feature_key`. Other fields
+            (`wishlist`, `janua_user_id`, `source_page`, `created_at`) are
+            forwarded if present.
+    """
+    settings = get_settings()
+    url = settings.crm_webhook_url
+    secret = settings.crm_webhook_secret
+
+    if not url or not secret:
+        # Pre-monetization / local dev — no CRM wired up. Silent no-op.
+        return
+
+    payload = _serialize_record(record)
+    # Stable JSON encoding (no whitespace) — what we sign is what we send.
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    signature = _sign(body, secret)
+    timestamp_header = payload["timestamp"]
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": f"sha256={signature}",
+        "X-Webhook-Timestamp": timestamp_header,
+        "User-Agent": "ceq-api/crm-sync",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.crm_webhook_timeout_seconds) as client:
+            resp = await client.post(url, content=body, headers=headers)
+        if resp.status_code >= 400:
+            logger.warning(
+                "CRM webhook returned %s for feature_key=%s (body truncated: %s)",
+                resp.status_code,
+                record.get("feature_key"),
+                resp.text[:200],
+            )
+            return
+        logger.info(
+            "CRM webhook delivered: feature_key=%s status=%s",
+            record.get("feature_key"),
+            resp.status_code,
+        )
+    except httpx.HTTPError as exc:
+        # Network blip, DNS, timeout — nothing to do. The DB row is intact.
+        logger.warning(
+            "CRM webhook failed: feature_key=%s error=%s",
+            record.get("feature_key"),
+            exc,
+        )
+    except Exception:  # pragma: no cover — defensive last-resort
+        logger.exception("Unexpected CRM webhook failure")

--- a/apps/studio/src/app/templates/[category]/page.tsx
+++ b/apps/studio/src/app/templates/[category]/page.tsx
@@ -16,7 +16,19 @@ import { MainLayout } from "@/components/layout/main-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TemplateCard } from "@/components/templates/template-card";
-import { getTemplates } from "@/lib/api";
+import { InterestGate } from "@/components/InterestGate";
+import { getTemplates, type Template } from "@/lib/api";
+
+/**
+ * Premium templates: tagged "pro" or "premium" in the backend.
+ * Until paid checkout ships, free users see InterestGate (email capture)
+ * over these instead of a 403. Free templates render as usual.
+ */
+function isPremiumTemplate(template: Template): boolean {
+  return template.tags.some((tag) =>
+    ["pro", "premium"].includes(tag.toLowerCase())
+  );
+}
 
 const CATEGORY_META: Record<
   string,
@@ -149,9 +161,22 @@ export default function TemplateCategoryPage() {
         {/* Template grid */}
         {!isLoading && !error && filteredTemplates.length > 0 && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-            {filteredTemplates.map((template) => (
-              <TemplateCard key={template.id} template={template} />
-            ))}
+            {filteredTemplates.map((template) =>
+              isPremiumTemplate(template) ? (
+                // Pro template: wrap with InterestGate (email capture instead of paywall).
+                <InterestGate
+                  key={template.id}
+                  featureKey="premium_render"
+                  variant="overlay"
+                  sourcePage={`templates/${category}`}
+                  className="h-full"
+                >
+                  <TemplateCard template={template} />
+                </InterestGate>
+              ) : (
+                <TemplateCard key={template.id} template={template} />
+              )
+            )}
           </div>
         )}
       </div>

--- a/apps/studio/src/components/InterestGate.tsx
+++ b/apps/studio/src/components/InterestGate.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+/**
+ * InterestGate — pre-monetization "email capture instead of paywall".
+ *
+ * Wrap any Pro feature with <InterestGate featureKey="..." variant="overlay">
+ * so free users see an email-capture form instead of a 403. When real billing
+ * arrives, swap the overlay for a checkout flow; the captured emails become
+ * the warm waitlist.
+ *
+ * Variants:
+ *   - inline   : compact banner, fits inline with surrounding content.
+ *   - overlay  : blurred backdrop over wrapped children (use to gate a Pro card).
+ *   - card     : standalone announcement card with optional benefits list.
+ *   - toast    : fixed bottom-right slide-in (good for "tried to use Pro" hints).
+ *
+ * Backend contract: POST /v1/interest/ -> 201 (new) | 200 (already_registered) | 4xx.
+ * See `apps/api/src/ceq_api/routers/interest.py`.
+ */
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Bell, Check, Loader2, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/contexts/auth-context";
+import { cn } from "@/lib/utils";
+import { getFeatureLabel, type Lang } from "@/lib/feature-labels";
+
+type Variant = "inline" | "overlay" | "card" | "toast";
+type SubmitState = "idle" | "submitting" | "success" | "already_registered" | "error";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5800";
+
+const COPY: Record<Lang, {
+  comingSoon: string;
+  notifyMe: string;
+  submit: string;
+  success: string;
+  alreadyRegistered: string;
+  error: string;
+  emailPlaceholder: string;
+  wishlistPlaceholder: string;
+  wishlistAria: string;
+  dismiss: string;
+}> = {
+  en: {
+    comingSoon: "Coming soon",
+    notifyMe: "Drop your email and we'll let you know.",
+    submit: "Notify me",
+    success: "Done. We'll be in touch.",
+    alreadyRegistered: "You're already on the list.",
+    error: "Couldn't register that. Try again?",
+    emailPlaceholder: "you@email.com",
+    wishlistPlaceholder: "What would unlock this for you?",
+    wishlistAria: "Wishlist",
+    dismiss: "Dismiss",
+  },
+  es: {
+    comingSoon: "Disponible pronto",
+    notifyMe: "Déjanos tu correo y te avisamos.",
+    submit: "Avísame",
+    success: "Listo. Te avisaremos.",
+    alreadyRegistered: "Ya estás en la lista.",
+    error: "No pudimos registrarlo. ¿Intentas otra vez?",
+    emailPlaceholder: "tu@correo.com",
+    wishlistPlaceholder: "¿Qué desbloquearía esto para ti?",
+    wishlistAria: "Lista de deseos",
+    dismiss: "Cerrar",
+  },
+};
+
+export interface InterestGateProps {
+  /** Feature identifier — must match `ALLOWED_FEATURES` server-side. */
+  featureKey: string;
+  /** Visual variant. `overlay` wraps `children` with a blur backdrop. */
+  variant?: Variant;
+  /** Override the auto-resolved feature label. */
+  featureLabel?: string;
+  /** Bullet list rendered in the `card` variant. */
+  benefits?: string[];
+  /** Show the wishlist textarea (only in `card` and `overlay`). */
+  showWishlist?: boolean;
+  /** Free-text page identifier sent to the backend (helps WTP analysis). */
+  sourcePage?: string;
+  /** Language for copy. Defaults to `en`. */
+  lang?: Lang;
+  /** Wrapped content — only used by the `overlay` variant. */
+  children?: ReactNode;
+  /** Optional CSS class for the wrapper. */
+  className?: string;
+  /** Called after a successful submit (new or duplicate). */
+  onSubmitted?: () => void;
+}
+
+export function InterestGate({
+  featureKey,
+  variant = "inline",
+  featureLabel,
+  benefits,
+  showWishlist = false,
+  sourcePage = "",
+  lang = "en",
+  children,
+  className,
+  onSubmitted,
+}: InterestGateProps) {
+  const t = COPY[lang];
+  const auth = useAuth();
+  const userEmail = auth.user?.email ?? "";
+  const userId = auth.user?.id ?? "";
+
+  const [email, setEmail] = useState(userEmail);
+  const [wishlist, setWishlist] = useState("");
+  const [state, setState] = useState<SubmitState>("idle");
+  const [dismissed, setDismissed] = useState(false);
+
+  // Sync email from auth once it loads.
+  useEffect(() => {
+    if (userEmail && !email) setEmail(userEmail);
+  }, [userEmail, email]);
+
+  const label = useMemo(
+    () => featureLabel ?? getFeatureLabel(featureKey, lang),
+    [featureLabel, featureKey, lang]
+  );
+
+  const isComplete = state === "success" || state === "already_registered";
+  const successMessage =
+    state === "already_registered" ? t.alreadyRegistered : t.success;
+
+  if (dismissed && variant === "toast") return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || state === "submitting") return;
+
+    setState("submitting");
+
+    let res: Response | null = null;
+    try {
+      res = await fetch(`${API_BASE}/v1/interest/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          feature_key: featureKey,
+          wishlist: wishlist.trim() || null,
+          janua_user_id: userId || null,
+          source_page: sourcePage || null,
+        }),
+      });
+    } catch {
+      setState("error");
+      return;
+    }
+
+    if (res.status === 201) {
+      setState("success");
+      onSubmitted?.();
+    } else if (res.status === 200) {
+      setState("already_registered");
+      onSubmitted?.();
+    } else {
+      setState("error");
+    }
+  };
+
+  // ---- Shared form pieces ----
+
+  const emailInput = (
+    <Input
+      type="email"
+      value={email}
+      onChange={(e) => setEmail(e.target.value)}
+      placeholder={t.emailPlaceholder}
+      required
+      className="flex-1 min-w-0"
+      aria-label="Email"
+    />
+  );
+
+  const wishlistTextarea =
+    showWishlist && (variant === "card" || variant === "overlay") ? (
+      <Textarea
+        value={wishlist}
+        onChange={(e) => setWishlist(e.target.value)}
+        placeholder={t.wishlistPlaceholder}
+        maxLength={2000}
+        rows={2}
+        className="w-full"
+        aria-label={t.wishlistAria}
+      />
+    ) : null;
+
+  const submitButton = (
+    <Button
+      type="submit"
+      size="sm"
+      disabled={state === "submitting" || !email}
+      className="gap-1 shrink-0"
+    >
+      {state === "submitting" ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : (
+        <Bell className="h-3 w-3" />
+      )}
+      {t.submit}
+    </Button>
+  );
+
+  // ---- Variants ----
+
+  if (variant === "toast") {
+    return (
+      <div
+        className={cn(
+          "fixed bottom-4 right-4 z-50 max-w-[min(24rem,calc(100vw-2rem))]",
+          className
+        )}
+        role="status"
+      >
+        <Card className="border-primary/30 shadow-lg">
+          <CardContent className="p-4">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-primary/10 p-2 shrink-0">
+                <Bell className="h-4 w-4 text-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <Badge variant="outline" className="text-xs mb-1">
+                  {t.comingSoon}
+                </Badge>
+                <p className="text-sm font-medium mb-2">{label}</p>
+                {isComplete ? (
+                  <div className="flex items-center gap-1.5 text-sm text-primary">
+                    <Check className="h-3.5 w-3.5" />
+                    {successMessage}
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit} className="flex gap-2">
+                    {emailInput}
+                    {submitButton}
+                  </form>
+                )}
+                {state === "error" && (
+                  <p className="text-xs text-destructive mt-1">{t.error}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setDismissed(true)}
+                className="text-muted-foreground hover:text-foreground shrink-0 p-1.5"
+                aria-label={t.dismiss}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (variant === "inline") {
+    return (
+      <div
+        className={cn(
+          "rounded-lg border border-primary/20 bg-gradient-to-r from-primary/5 to-primary/10 p-4",
+          className
+        )}
+      >
+        <div className="flex items-center gap-2 mb-2">
+          <Bell className="h-4 w-4 text-primary shrink-0" />
+          <Badge variant="outline" className="text-xs">
+            {t.comingSoon}
+          </Badge>
+          <span className="text-sm font-medium">{label}</span>
+        </div>
+        {isComplete ? (
+          <div className="flex items-center gap-1.5 text-sm text-primary">
+            <Check className="h-3.5 w-3.5" />
+            {successMessage}
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+            {emailInput}
+            {submitButton}
+          </form>
+        )}
+        {state === "error" && (
+          <p className="text-xs text-destructive mt-1">{t.error}</p>
+        )}
+      </div>
+    );
+  }
+
+  if (variant === "card") {
+    return (
+      <Card className={cn("border-primary/20 overflow-hidden relative", className)}>
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-primary/10 pointer-events-none" />
+        <CardContent className="relative p-6 sm:p-8 text-center">
+          <div className="mx-auto rounded-full bg-primary/10 p-3 w-fit mb-4">
+            <Bell className="h-6 w-6 text-primary" />
+          </div>
+          <Badge variant="outline" className="text-xs mb-3">
+            {t.comingSoon}
+          </Badge>
+          <h3 className="text-lg font-bold mb-2">{label}</h3>
+          <p className="text-sm text-muted-foreground mb-4 max-w-md mx-auto">
+            {t.notifyMe}
+          </p>
+
+          {benefits && benefits.length > 0 && (
+            <ul className="text-sm text-left max-w-xs mx-auto space-y-1.5 mb-5">
+              {benefits.map((b, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className="text-primary mt-0.5">✓</span>
+                  <span className="text-muted-foreground">{b}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {isComplete ? (
+            <div className="flex items-center justify-center gap-1.5 text-sm text-primary">
+              <Check className="h-4 w-4" />
+              {successMessage}
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="max-w-sm mx-auto space-y-3">
+              {emailInput}
+              {wishlistTextarea}
+              {submitButton}
+            </form>
+          )}
+          {state === "error" && (
+            <p className="text-xs text-destructive mt-2">{t.error}</p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // variant === "overlay"
+  return (
+    <div className={cn("relative rounded-lg overflow-hidden", className)}>
+      {/* Render wrapped content underneath, blurred */}
+      {children ? (
+        <div aria-hidden="true" className="pointer-events-none">
+          {children}
+        </div>
+      ) : null}
+
+      <div className="absolute inset-0 bg-background/80 backdrop-blur-sm z-10 flex items-center justify-center">
+        <div className="text-center p-6 max-w-sm">
+          <div className="mx-auto rounded-full bg-primary/10 p-3 w-fit mb-3">
+            <Bell className="h-5 w-5 text-primary" />
+          </div>
+          <Badge variant="outline" className="text-xs mb-2">
+            {t.comingSoon}
+          </Badge>
+          <h3 className="text-base font-bold mb-1">{label}</h3>
+          <p className="text-sm text-muted-foreground mb-4">{t.notifyMe}</p>
+          {isComplete ? (
+            <div className="flex items-center justify-center gap-1.5 text-sm text-primary">
+              <Check className="h-4 w-4" />
+              {successMessage}
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-2">
+              {emailInput}
+              {wishlistTextarea}
+              {submitButton}
+            </form>
+          )}
+          {state === "error" && (
+            <p className="text-xs text-destructive mt-1">{t.error}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default InterestGate;

--- a/apps/studio/src/lib/feature-labels.ts
+++ b/apps/studio/src/lib/feature-labels.ts
@@ -1,0 +1,40 @@
+/**
+ * Feature key → i18n display labels for InterestGate.
+ *
+ * Keep keys in sync with `ALLOWED_FEATURES` in
+ * `apps/api/src/ceq_api/routers/interest.py` — submitting an unknown key
+ * will fail validation server-side.
+ */
+
+export type Lang = "en" | "es";
+
+export type FeatureKey =
+  | "premium_render"
+  | "training_access"
+  | "team_seats"
+  | "early_access";
+
+export const FEATURE_LABELS: Record<FeatureKey, Record<Lang, string>> = {
+  premium_render: {
+    en: "Premium templates",
+    es: "Plantillas premium",
+  },
+  training_access: {
+    en: "Custom model training",
+    es: "Entrenamiento de modelos a medida",
+  },
+  team_seats: {
+    en: "Team seats and collaboration",
+    es: "Asientos de equipo y colaboración",
+  },
+  early_access: {
+    en: "Early access",
+    es: "Acceso anticipado",
+  },
+};
+
+export function getFeatureLabel(featureKey: string, lang: Lang = "en"): string {
+  const entry = FEATURE_LABELS[featureKey as FeatureKey];
+  if (!entry) return featureKey;
+  return entry[lang] ?? entry.en ?? featureKey;
+}


### PR DESCRIPTION
Implements RFC 0013 interim pattern. CEQ DeepInfra cost basis is volatile, so locking premium templates behind paywall before WTP signal would either underprice (lose money) or overprice (lose users). InterestGate captures email demand instead. Switches to real paywall once Tulana confidence + PMF gate flips. SQLAlchemy model + Alembic migration + FastAPI router + React component (4 variants). Operator: alembic upgrade head, set 3 env vars, register PhyneCRM webhook.