### PR TITLE
feat(enclii): declare status entries via enclii.yaml

### DIFF
--- a/enclii.yaml
+++ b/enclii.yaml
@@ -1,0 +1,24 @@
+apiVersion: enclii.dev/v1
+kind: Service
+metadata:
+  name: ceq
+  project: ceq
+spec:
+  # Status-only declaration. CEQ's runtime + network sections will be
+  # added when the service is fully onboarded for deploy through the
+  # platform pipeline.
+  #
+  # Until then, the entries below are the zero-touch source-of-truth
+  # for status.madfam.io. The platform regenerate handler
+  # (`POST /v1/admin/status/regenerate`, enclii#162) projects them into
+  # `apps/status/k8s/madfam/configmap.yaml`. This replaces the manual
+  # configmap edit that landed in enclii#160 (zero-touch policy
+  # violation, see internal-devops/rfcs/0014 for the policy).
+  status:
+    enabled: true
+    entries:
+      - name: CEQ Studio
+        url: https://ceq.lol
+        group: CEQ
+        family: Content & Creative
+        description: ComfyUI creative engine


### PR DESCRIPTION
## Summary

Phase 2 of the zero-touch onboarding compliance arc. Declares this repo's `status.madfam.io` entries via the new `enclii.yaml` `status:` block introduced by [enclii#162](https://github.com/madfam-org/enclii/pull/162)'s regenerate handler.

The platform regenerate handler (`POST /v1/admin/status/regenerate`) projects every ecosystem repo's `enclii.yaml` `status.entries[]` into the platform's `apps/status/k8s/madfam/configmap.yaml`. With this PR, that projection is non-trivial for this repo — its entries flow from here to the configmap on next regenerate, instead of being authored in the configmap directly.

This replaces the manual configmap edit pattern that landed in [enclii#160](https://github.com/madfam-org/enclii/pull/160) (zero-touch policy violation per [internal-devops/rfcs/0014](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0014-zero-touch-onboarding-policy.md)).

Source-of-truth lines for the entries copied here live at [`apps/status/k8s/madfam/configmap.yaml`](https://github.com/madfam-org/enclii/blob/main/apps/status/k8s/madfam/configmap.yaml) in the enclii repo.

## Test plan

- [ ] CI passes (yaml syntax + repo's existing checks)
- [ ] After merge, run `POST /v1/admin/status/regenerate` on the platform; configmap entries for this group remain unchanged (regenerate is idempotent against the existing configmap content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)