### PR TITLE
feat(ci): convert deploy to GitOps via kustomize digest pin (closes #16)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,14 +1,25 @@
 # =============================================================================
-# CEQ CI/CD Pipeline
+# CEQ CI/CD Pipeline (GitOps)
 # =============================================================================
 #
-# Builds and deploys CEQ to production on push to main branch.
-# Triggered by: push to main, manual dispatch
+# Builds + pushes images to GHCR, then commits the new manifest-list digest
+# to `infrastructure/k8s/kustomization.yaml`. ArgoCD's `ceq-services`
+# application reconciles the change within ~3 min — no kubectl apply from
+# CI, no kube-apiserver access required.
 #
-# Required Secrets:
-#   - GHCR_TOKEN: GitHub Container Registry token
-#   - KUBECONFIG_BASE64: Base64-encoded kubeconfig for k3s cluster
-#   - CF_TUNNEL_TOKEN: Cloudflare tunnel token (optional, for tunnel updates)
+# Why GitOps: ARC runner pods in the `arc-runners` namespace are
+# NetworkPolicy-isolated from kube-apiserver (verified 2026-04-28T03:10Z —
+# `kubectl exec -n arc-runners <pod> -- curl https://10.43.0.1:443/`
+# returns exit 7). Direct `kubectl apply` from inside a runner is
+# architecturally broken. Pattern mirrors rondelio's deploy-*.yml,
+# dhanam's deploy-prod.yml, and 6 other repos in the ecosystem.
+# Closes ceq#16.
+#
+# Required secrets:
+#   - GITHUB_TOKEN: implicit, used for GHCR push
+#   - MADFAM_BOT_PAT (optional): bot PAT for the GitOps commit. Falls back
+#     to GITHUB_TOKEN, but a dedicated bot identity is preferred so
+#     deploy commits show up as `madfam-deploy-bot` in `git log`.
 #
 # =============================================================================
 
@@ -21,6 +32,7 @@ on:
       - 'apps/**'
       - 'infrastructure/**'
       - '.github/workflows/deploy.yaml'
+      - '!infrastructure/k8s/kustomization.yaml'
   workflow_dispatch:
     inputs:
       environment:
@@ -32,9 +44,17 @@ on:
           - production
           - staging
 
+# Serialise deploy commits so two concurrent runs can't fight over
+# kustomization.yaml. Newer pushes cancel older queued runs.
+concurrency:
+  group: ceq-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/madfam-org/ceq
+  # Canonical image namespace. All three services live at
+  # ghcr.io/madfam-org/ceq-{api,studio,worker} (dash-form, not slash-form).
+  IMAGE_NAMESPACE: ghcr.io/madfam-org
 
 jobs:
   # ===========================================================================
@@ -49,7 +69,7 @@ jobs:
       id-token: write
 
     outputs:
-      image-tag: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -72,14 +92,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}/api
+          images: ${{ env.IMAGE_NAMESPACE }}/ceq-api
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
-        id: build-api
+        id: build
         with:
           context: ./apps/api
           push: true
@@ -92,7 +112,24 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/api@${{ steps.build-api.outputs.digest }}
+          cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-api@${{ steps.build.outputs.digest }}
+
+      - name: Resolve manifest-list digest
+        id: digest
+        run: |
+          set -euo pipefail
+          # docker buildx imagetools inspect returns the manifest-list digest
+          # for multi-arch images. `docker manifest inspect | jq` returns null
+          # for multi-arch (enclii#136).
+          DIGEST=$(docker buildx imagetools inspect \
+            "${{ env.IMAGE_NAMESPACE }}/ceq-api:${{ github.sha }}" \
+            | awk '/^Digest:/{print $2; exit}')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to resolve digest" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved api digest: ${DIGEST}"
 
   # ===========================================================================
   # Build Studio Image
@@ -106,7 +143,7 @@ jobs:
       id-token: write
 
     outputs:
-      image-tag: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -129,14 +166,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}/studio
+          images: ${{ env.IMAGE_NAMESPACE }}/ceq-studio
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
-        id: build-studio
+        id: build
         with:
           context: .
           file: ./apps/studio/Dockerfile
@@ -155,7 +192,21 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/studio@${{ steps.build-studio.outputs.digest }}
+          cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-studio@${{ steps.build.outputs.digest }}
+
+      - name: Resolve manifest-list digest
+        id: digest
+        run: |
+          set -euo pipefail
+          DIGEST=$(docker buildx imagetools inspect \
+            "${{ env.IMAGE_NAMESPACE }}/ceq-studio:${{ github.sha }}" \
+            | awk '/^Digest:/{print $2; exit}')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to resolve digest" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved studio digest: ${DIGEST}"
 
   # ===========================================================================
   # Build Worker Image (Optional)
@@ -166,10 +217,16 @@ jobs:
     permissions:
       contents: read
       packages: write
-    # Only build worker on manual dispatch or when worker files change
+    # Only build worker on manual dispatch or when worker files change.
+    # Worker is also currently failing on a separate concern (Dockerfile
+    # `pip install -e .` fails because README.md isn't in the build
+    # context); see the PR body. Out of scope for this GitOps refactor.
     if: |
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.head_commit.modified, 'apps/workers/')
+
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -189,13 +246,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}/worker
+          images: ${{ env.IMAGE_NAMESPACE }}/ceq-worker
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
+        id: build
         with:
           context: ./apps/workers
           push: true
@@ -204,97 +262,96 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Resolve manifest-list digest
+        id: digest
+        run: |
+          set -euo pipefail
+          DIGEST=$(docker buildx imagetools inspect \
+            "${{ env.IMAGE_NAMESPACE }}/ceq-worker:${{ github.sha }}" \
+            | awk '/^Digest:/{print $2; exit}')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to resolve digest" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved worker digest: ${DIGEST}"
+
   # ===========================================================================
-  # Deploy to Kubernetes
+  # GitOps Deploy: commit digests to kustomization.yaml
   # ===========================================================================
+  #
+  # Replaces the prior `kubectl apply -k` step. ARC runner pods are
+  # NetworkPolicy-isolated from kube-apiserver, so direct cluster access
+  # from CI is not viable. Instead: pin the image digests in the manifest,
+  # commit + push to main, and let ArgoCD reconcile. The ceq-db-migrate
+  # Job carries an ArgoCD PreSync hook annotation, so alembic upgrade head
+  # runs before the Deployments roll.
   deploy:
-    name: Deploy to K8s
+    name: Commit deploy digests (GitOps)
     runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: [build-api, build-studio]
+    # Don't gate on build-worker — it only runs when worker files change.
     environment: production
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
         with:
-          version: 'v1.28.0'
+          token: ${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
-      - name: Set up kustomize
-        uses: imranismail/setup-kustomize@v2
-        with:
-          kustomize-version: '5.4.3'
-
-      - name: Configure kubeconfig
+      - name: Install kustomize
         run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
+          curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz" | tar xz
+          sudo mv kustomize /usr/local/bin/
 
-      - name: Update image tags in kustomization
+      - name: Commit image digests
         run: |
-          cd infrastructure/k8s
-          # Update API image
-          kustomize edit set image ghcr.io/madfam-org/ceq/api=${{ env.IMAGE_PREFIX }}/ceq-api:${{ github.sha }}
-          # Update Studio image
-          kustomize edit set image ghcr.io/madfam-org/ceq/studio=${{ env.IMAGE_PREFIX }}/ceq-studio:${{ github.sha }}
+          set -euo pipefail
+          API_DIGEST="${{ needs.build-api.outputs.digest }}"
+          STUDIO_DIGEST="${{ needs.build-studio.outputs.digest }}"
+          WORKER_DIGEST="${{ needs.build-worker.outputs.digest }}"
 
-      - name: Deploy to cluster
-        run: |
-          kubectl apply -k infrastructure/k8s/
-
-          # Wait for rollouts
-          kubectl rollout status deployment/ceq-api -n ceq --timeout=180s
-          kubectl rollout status deployment/ceq-studio -n ceq --timeout=180s
-
-      - name: Run database migrations
-        run: |
-          # Delete old migration job if exists
-          kubectl delete job ceq-db-migrate -n ceq --ignore-not-found=true
-
-          # Apply migration job
-          kubectl apply -f infrastructure/k8s/db-migrate-job.yaml
-
-          # Wait for migration to complete
-          kubectl wait --for=condition=complete job/ceq-db-migrate -n ceq --timeout=120s || {
-            echo "Migration failed. Checking logs..."
-            kubectl logs job/ceq-db-migrate -n ceq
+          if [ -z "$API_DIGEST" ] || [ -z "$STUDIO_DIGEST" ]; then
+            echo "Missing required digest (api=$API_DIGEST, studio=$STUDIO_DIGEST)" >&2
             exit 1
-          }
-
-          echo "✅ Database migrations completed"
-
-      - name: Verify deployment
-        run: |
-          echo "=== Deployment Status ==="
-          kubectl get pods -n ceq
-
-          echo ""
-          echo "=== Service Endpoints ==="
-          kubectl get svc -n ceq
-
-      - name: Health check
-        run: |
-          # Wait a moment for services to stabilize
-          sleep 10
-
-          # Check API health
-          API_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://api.ceq.lol/health || echo "000")
-          if [ "$API_STATUS" == "200" ]; then
-            echo "✅ API is healthy (HTTP $API_STATUS)"
-          else
-            echo "⚠️ API check returned HTTP $API_STATUS"
           fi
 
-          # Check Studio
-          STUDIO_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://ceq.lol || echo "000")
-          if [ "$STUDIO_STATUS" == "200" ] || [ "$STUDIO_STATUS" == "301" ] || [ "$STUDIO_STATUS" == "302" ]; then
-            echo "✅ Studio is healthy (HTTP $STUDIO_STATUS)"
-          else
-            echo "⚠️ Studio check returned HTTP $STUDIO_STATUS"
-          fi
+          git config user.name "madfam-deploy-bot"
+          git config user.email "deploy-bot@madfam.io"
+
+          for ATTEMPT in 1 2 3; do
+            git fetch origin main
+            git reset --hard origin/main
+            (
+              cd infrastructure/k8s
+              kustomize edit set image \
+                "ghcr.io/madfam-org/ceq-api=ghcr.io/madfam-org/ceq-api@${API_DIGEST}"
+              kustomize edit set image \
+                "ghcr.io/madfam-org/ceq-studio=ghcr.io/madfam-org/ceq-studio@${STUDIO_DIGEST}"
+              # Worker digest is optional — only present when build-worker ran.
+              if [ -n "$WORKER_DIGEST" ]; then
+                kustomize edit set image \
+                  "ghcr.io/madfam-org/ceq-worker=ghcr.io/madfam-org/ceq-worker@${WORKER_DIGEST}"
+              fi
+            )
+            git add infrastructure/k8s/kustomization.yaml
+            if git diff --staged --quiet; then
+              echo "No changes to commit (digests already pinned)"
+              exit 0
+            fi
+            git commit -m "deploy(ceq): update digests to ${GITHUB_SHA::8}"
+            if git push origin main; then
+              echo "Pushed deploy commit on attempt ${ATTEMPT}"
+              exit 0
+            fi
+            echo "Push rejected (concurrent commit?). Retry ${ATTEMPT}/3 after backoff..."
+            sleep $((ATTEMPT * 10))
+          done
+          echo "Failed to push deploy commit after 3 attempts" >&2
+          exit 1
 
   # ===========================================================================
   # Notify on completion
@@ -309,12 +366,15 @@ jobs:
       - name: Deployment summary
         run: |
           if [ "${{ needs.deploy.result }}" == "success" ]; then
-            echo "🚀 CEQ deployed successfully!"
+            echo "CEQ deploy commit pushed. ArgoCD reconciles within ~3 min."
             echo ""
             echo "Endpoints:"
             echo "  - https://ceq.lol (Studio)"
             echo "  - https://api.ceq.lol (API)"
             echo "  - wss://ws.ceq.lol (WebSocket)"
+            echo ""
+            echo "Verify rollout:"
+            echo "  ssh ssh.madfam.io 'sudo k3s kubectl -n ceq get pods'"
           else
-            echo "❌ Deployment failed. Check logs for details."
+            echo "Deploy commit failed. Check logs for details."
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,28 +240,59 @@ const ERROR_MESSAGES = [
 
 ## Kubernetes Deployment
 
-### Namespace
+### Production deploys: GitOps via ArgoCD (since 2026-04-28, ceq#16)
+
+CEQ deploys through the same auto-digest GitOps loop as the rest of the
+MADFAM ecosystem. `.github/workflows/deploy.yaml` builds + pushes images
+to GHCR, resolves each manifest-list digest via
+`docker buildx imagetools inspect` (NOT `docker manifest inspect | jq`
+— that returns null on multi-arch, see enclii#136), then commits the
+new digests to `infrastructure/k8s/kustomization.yaml` as
+`madfam-deploy-bot`. ArgoCD's `ceq-services` application picks up the
+new digests within ~3 min.
+
+**No `kubectl apply` from CI.** ARC runner pods are NetworkPolicy-isolated
+from the kube-apiserver (verified 2026-04-28); direct cluster access from
+inside a runner returns exit 7. The GitOps loop is the only deploy path.
+
+**Image-name convention:** all three production images use dash-form:
+`ghcr.io/madfam-org/ceq-{api,studio,worker}`. Earlier manifests had a
+mix (`ghcr.io/madfam/ceq-api`, `ghcr.io/madfam-org/ceq/studio`); fixed
+to dash-form in the GitOps refactor PR. New manifests should match.
+
+**Database migrations** run as a Job with `argocd.argoproj.io/hook: PreSync`
++ `hook-delete-policy: BeforeHookCreation`, so each ArgoCD sync runs
+`alembic upgrade head` before the Deployments roll. `seed-templates-job.yaml`
+is a manual one-shot, intentionally excluded from the kustomize bundle.
+
+### Bootstrap (first-time only)
+
 ```bash
-kubectl apply -f infrastructure/k8s/namespace.yaml
+# Namespace + secrets are operator-only; runners can't reach the API.
+ssh ssh.madfam.io
+sudo k3s kubectl apply -f infrastructure/k8s/namespace.yaml
+sudo k3s kubectl apply -f infrastructure/k8s/secrets.local.yaml
 ```
 
-### Secrets
-```bash
-# Copy template and fill in values
-cp infrastructure/k8s/secrets.prod.yaml infrastructure/k8s/secrets.local.yaml
-vim infrastructure/k8s/secrets.local.yaml
-kubectl apply -f infrastructure/k8s/secrets.local.yaml
-```
+After that, ArgoCD owns the rollout.
 
-### Deploy
+### Manual one-shots (operator)
+
 ```bash
-kubectl apply -k infrastructure/k8s/
+# Re-seed templates after a fresh DB:
+ssh ssh.madfam.io
+sudo k3s kubectl apply -f infrastructure/k8s/seed-templates-job.yaml
+
+# Force a re-migration (delete + ArgoCD will recreate the PreSync Job):
+sudo k3s kubectl -n ceq delete job ceq-db-migrate
 ```
 
 ### Verify
+
 ```bash
-kubectl get pods -n ceq
-kubectl logs -n ceq deployment/ceq-api
+ssh ssh.madfam.io
+sudo k3s kubectl -n ceq get pods
+sudo k3s kubectl -n ceq logs deployment/ceq-api
 ```
 
 ## Important Notes

--- a/infrastructure/k8s/api-deployment.yaml
+++ b/infrastructure/k8s/api-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: ceq-api
-          image: ghcr.io/madfam/ceq-api:latest
+          image: ghcr.io/madfam-org/ceq-api:latest
           ports:
             - containerPort: 5800
               name: http

--- a/infrastructure/k8s/db-migrate-job.yaml
+++ b/infrastructure/k8s/db-migrate-job.yaml
@@ -1,14 +1,14 @@
 # CEQ Database Migration Job
 #
-# Run migrations on first deployment or after schema changes:
+# Managed by kustomize + ArgoCD. Runs as a PreSync hook before each ArgoCD
+# sync, so a new image digest committed to kustomization.yaml triggers a
+# fresh migration run before the Deployments roll. Hook-delete-policy
+# `BeforeHookCreation` makes ArgoCD delete the prior Job before creating
+# the next one (Job names are immutable, so this is required for re-runs).
+#
+# Manual one-shot:
+#   kubectl delete job ceq-db-migrate -n ceq --ignore-not-found=true
 #   kubectl apply -f db-migrate-job.yaml
-#
-# Check status:
-#   kubectl get jobs -n ceq
-#   kubectl logs job/ceq-db-migrate -n ceq
-#
-# Delete to re-run:
-#   kubectl delete job ceq-db-migrate -n ceq
 ---
 apiVersion: batch/v1
 kind: Job
@@ -18,6 +18,10 @@ metadata:
   labels:
     app: ceq
     component: migration
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   ttlSecondsAfterFinished: 300  # Auto-delete after 5 minutes
   backoffLimit: 3
@@ -30,7 +34,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migrate
-          image: ghcr.io/madfam/ceq-api:latest
+          image: ghcr.io/madfam-org/ceq-api:latest
           command:
             - /bin/sh
             - -c
@@ -39,55 +43,6 @@ spec:
               cd /app
               python -m alembic upgrade head
               echo "Migrations complete!"
-          env:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: ceq-secrets
-                  key: database-url
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: ceq-secrets
-                  key: redis-url
-          resources:
-            requests:
-              memory: "128Mi"
-              cpu: "50m"
-            limits:
-              memory: "256Mi"
-              cpu: "200m"
----
-# Optional: Seed templates job
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ceq-seed-templates
-  namespace: ceq
-  labels:
-    app: ceq
-    component: seed
-spec:
-  ttlSecondsAfterFinished: 300
-  backoffLimit: 1
-  template:
-    metadata:
-      labels:
-        app: ceq
-        component: seed
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: seed
-          image: ghcr.io/madfam/ceq-api:latest
-          command:
-            - /bin/sh
-            - -c
-            - |
-              echo "Seeding CEQ templates..."
-              cd /app
-              python -m ceq_api.scripts.seed_db
-              echo "Seeding complete!"
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -3,9 +3,9 @@
 # Deploy all CEQ resources with:
 #   kubectl apply -k infrastructure/k8s/
 #
-# For environment-specific deployments, create overlays:
-#   infrastructure/k8s/overlays/production/kustomization.yaml
-#   infrastructure/k8s/overlays/staging/kustomization.yaml
+# In production, ArgoCD's `ceq-services` application reconciles this
+# kustomization. CI commits image digests below via
+# `kustomize edit set image` after each successful build.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -24,19 +24,26 @@ resources:
   - api-deployment.yaml
   - studio-deployment.yaml
   - worker-deployment.yaml
+  # PreSync hook job — runs alembic upgrade head before deployments roll.
+  - db-migrate-job.yaml
   # cloudflared removed 2026-04-25: ceq-prod tunnel deleted on Cloudflare side
   # 2026-04-09; ceq.lol / api.ceq.lol / ws.ceq.lol DNS now routes through the
   # main enclii-prod tunnel at the platform level. No per-namespace cloudflared
   # needed. Old config + leaked token (R1 audit) removed in this commit.
   # - cloudflared.yaml
+  # seed-templates-job.yaml is intentionally excluded — manual one-shot only.
 
-# Image customization for different environments
+# Image customization. CI's deploy.yaml workflow rewrites these entries
+# via `kustomize edit set image <name>=<name>@sha256:...` on every build,
+# pinning each Deployment + the migration Job to a content-addressed
+# digest. ArgoCD's `ceq-services` application reconciles the change
+# within ~3 min.
 images:
-  - name: ghcr.io/madfam/ceq-api
+  - name: ghcr.io/madfam-org/ceq-api
     newTag: latest
-  - name: ghcr.io/madfam/ceq-studio
+  - name: ghcr.io/madfam-org/ceq-studio
     newTag: latest
-  - name: ghcr.io/madfam/ceq-worker
+  - name: ghcr.io/madfam-org/ceq-worker
     newTag: latest
 
 # ConfigMap generator for environment-specific values

--- a/infrastructure/k8s/seed-templates-job.yaml
+++ b/infrastructure/k8s/seed-templates-job.yaml
@@ -1,0 +1,55 @@
+# CEQ Template Seeder (manual one-shot, NOT in kustomize bundle)
+#
+# Run only when bootstrapping a fresh database:
+#   kubectl apply -f infrastructure/k8s/seed-templates-job.yaml
+#
+# Intentionally excluded from `kustomization.yaml` so it does not run on
+# every ArgoCD sync.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ceq-seed-templates
+  namespace: ceq
+  labels:
+    app: ceq
+    component: seed
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: ceq
+        component: seed
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: seed
+          image: ghcr.io/madfam-org/ceq-api:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Seeding CEQ templates..."
+              cd /app
+              python -m ceq_api.scripts.seed_db
+              echo "Seeding complete!"
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ceq-secrets
+                  key: database-url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ceq-secrets
+                  key: redis-url
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"

--- a/infrastructure/k8s/studio-deployment.yaml
+++ b/infrastructure/k8s/studio-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: ghcr-credentials
       containers:
         - name: ceq-studio
-          image: ghcr.io/madfam-org/ceq/studio:latest
+          image: ghcr.io/madfam-org/ceq-studio:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 5801

--- a/infrastructure/k8s/worker-deployment.yaml
+++ b/infrastructure/k8s/worker-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: ceq-worker
-          image: ghcr.io/madfam/ceq-worker:latest
+          image: ghcr.io/madfam-org/ceq-worker:latest
           env:
             - name: WORKER_ID
               valueFrom:


### PR DESCRIPTION
## Summary

Converts CEQ's deploy workflow from direct `kubectl apply -k` (broken — see below) to the canonical GitOps pattern already in production across rondelio, dhanam, karafiel, forgesight, almanac, coforma, phyne-crm, and bit. Closes #16.

**Pattern**: build + push → `docker buildx imagetools inspect` for manifest-list digest → `kustomize edit set image …@sha256:…` → commit to `infrastructure/k8s/kustomization.yaml` as `madfam-deploy-bot` → ArgoCD `ceq-services` reconciles within ~3 min.

## Why

ARC runner pods in the `arc-runners` namespace are NetworkPolicy-isolated from the kube-apiserver. Verified 2026-04-28T03:10Z:

```
$ kubectl exec -n arc-runners madfam-runners-blue-csghr-runner-29mhr -- \
    curl -sk -m 5 https://10.43.0.1:443/
HTTP 000  (exit 7)
```

So `kubectl apply -k infrastructure/k8s/` from inside the workflow's `Deploy to K8s` job has never worked since the cluster gained that NetworkPolicy. Five deploy attempts since 2026-04-25 all failed at the kubectl step. Architecture rationale in `claudedocs/ecosystem-deploy-+-status-architecture-2026-04-28.md` Pillar 1.

## What changed

| File | Change |
|---|---|
| `.github/workflows/deploy.yaml` | Replace `Deploy to K8s` with `Commit deploy digests (GitOps)`. Each `build-*` job exports a `digest` output; deploy job runs `kustomize edit set image` for api + studio (+ worker when present), commits + pushes with retry-on-conflict. Concurrency group `ceq-deploy-${ref}`. Uses `MADFAM_BOT_PAT` with `GITHUB_TOKEN` fallback per karafiel#38. |
| `infrastructure/k8s/db-migrate-job.yaml` | **Option A** from #16: ArgoCD `PreSync` hook + `hook-delete-policy: BeforeHookCreation` + `sync-wave: "-1"`. Each ArgoCD sync recreates the Job and runs `alembic upgrade head` before Deployments roll. Now part of the kustomize bundle. |
| `infrastructure/k8s/seed-templates-job.yaml` | New file. Split out the optional template-seeder Job from `db-migrate-job.yaml`, kept out of the kustomize bundle (manual one-shot only). |
| `infrastructure/k8s/kustomization.yaml` | Add `db-migrate-job.yaml` to resources. Normalise image namespace to canonical dash-form `ghcr.io/madfam-org/ceq-{api,studio,worker}`. |
| `infrastructure/k8s/{api,studio,worker}-deployment.yaml` | Align image refs to dash-form (was a mix of `ghcr.io/madfam/ceq-api`, `ghcr.io/madfam-org/ceq/studio`, `ghcr.io/madfam/ceq-worker`). |
| `CLAUDE.md` | Document the GitOps flow + the dash-form image-name convention. |

## Migration handling — Option A vs B

**Picked Option A** (kustomize-managed PreSync hook). Rationale:
- The migration runs deterministically before each rollout, never against a partially-rolled fleet.
- ArgoCD's `BeforeHookCreation` policy handles the Job-name-immutability problem cleanly (no manual `kubectl delete job` from CI).
- Sync-wave `-1` guarantees ordering vs the Deployments without any explicit wait.
- Same pattern dhanam already runs in production.

If migrations later become expensive enough that they shouldn't run on every deploy, the trivial follow-up is to flip the file to a `workflow_dispatch`-only manual Job.

## Worker build status

`Build Worker` has failed in the last 2 runs that triggered it (run 25030756141 onward). **Unrelated to this PR's scope.** Root cause: `apps/workers/Dockerfile`'s `pip install -e .` calls into `hatchling`, which raises `OSError: Readme file does not exist: README.md` because the build context drops the README. The `if:` gate keeps the worker build from running on most pushes, so this bug only surfaces on `workflow_dispatch` or `apps/workers/**` changes. It existed before this PR and remains afterward — to be fixed separately.

## Verification (manual, post-merge)

```bash
# After merge, push any change touching apps/** to trigger a deploy:
# 1. Confirm build-api + build-studio jobs succeed and resolve digests
# 2. Confirm `Commit deploy digests` job pushes to main as madfam-deploy-bot
gh run list --workflow deploy.yaml --limit 1

# 3. Confirm ArgoCD picks up the change within ~3 min:
ssh ssh.madfam.io
sudo k3s kubectl -n ceq get pods -w
sudo k3s kubectl -n argocd get app ceq-services -o jsonpath='{.status.sync.status}'
```

## Test plan

- [ ] Reviewer confirms YAML lints (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yaml'))"` already passes locally)
- [ ] Reviewer confirms `kustomize build infrastructure/k8s/` produces a clean bundle with all 3 deployments + the migration Job
- [ ] After merge, first deploy run shipping a new commit lands on `main` as `madfam-deploy-bot`
- [ ] ArgoCD `ceq-services` shows `Synced` + `Healthy` within 5 min
- [ ] `kubectl -n ceq get pods` shows the new `IMAGE_ID` matching the digest in `kustomization.yaml`
- [ ] Migration Job completed before Deployments became Ready

## References

- Architecture doc: `/Users/aldoruizluna/labspace/claudedocs/ecosystem-deploy-+-status-architecture-2026-04-28.md` (Pillar 1)
- Reference workflow: `rondelio/.github/workflows/deploy-gateway.yml`
- enclii#136: `docker manifest inspect | jq` returns null on multi-arch — use `buildx imagetools inspect`
- karafiel#38: `MADFAM_BOT_PAT` with `GITHUB_TOKEN` fallback for GitOps push

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)