### PR TITLE
fix(deploy): retry manifest-list digest resolution on GHCR race

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -121,15 +121,23 @@ jobs:
           # docker buildx imagetools inspect returns the manifest-list digest
           # for multi-arch images. `docker manifest inspect | jq` returns null
           # for multi-arch (enclii#136).
-          DIGEST=$(docker buildx imagetools inspect \
-            "${{ env.IMAGE_NAMESPACE }}/ceq-api:${{ github.sha }}" \
-            | awk '/^Digest:/{print $2; exit}')
-          if [ -z "$DIGEST" ]; then
-            echo "Failed to resolve digest" >&2
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "Resolved api digest: ${DIGEST}"
+          # GHCR has eventual-consistency between push and pull-side visibility;
+          # retry with backoff (ceq#19) — observed 5 consecutive Deploy failures
+          # 2026-04-28 on "manifest unknown" within 3s of push.
+          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-api:${{ github.sha }}"
+          for attempt in 1 2 3 4 5; do
+            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
+              if [ -n "$DIGEST" ]; then
+                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+                echo "Resolved api digest on attempt ${attempt}: ${DIGEST}"
+                exit 0
+              fi
+            fi
+            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
+            sleep $((attempt * 5))
+          done
+          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
+          exit 1
 
   # ===========================================================================
   # Build Studio Image
@@ -198,15 +206,21 @@ jobs:
         id: digest
         run: |
           set -euo pipefail
-          DIGEST=$(docker buildx imagetools inspect \
-            "${{ env.IMAGE_NAMESPACE }}/ceq-studio:${{ github.sha }}" \
-            | awk '/^Digest:/{print $2; exit}')
-          if [ -z "$DIGEST" ]; then
-            echo "Failed to resolve digest" >&2
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "Resolved studio digest: ${DIGEST}"
+          # GHCR eventual-consistency retry — see Build API for rationale.
+          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-studio:${{ github.sha }}"
+          for attempt in 1 2 3 4 5; do
+            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
+              if [ -n "$DIGEST" ]; then
+                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+                echo "Resolved studio digest on attempt ${attempt}: ${DIGEST}"
+                exit 0
+              fi
+            fi
+            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
+            sleep $((attempt * 5))
+          done
+          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
+          exit 1
 
   # ===========================================================================
   # Build Worker Image (Optional)
@@ -266,14 +280,21 @@ jobs:
         id: digest
         run: |
           set -euo pipefail
-          DIGEST=$(docker buildx imagetools inspect \
-            "${{ env.IMAGE_NAMESPACE }}/ceq-worker:${{ github.sha }}" \
-            | awk '/^Digest:/{print $2; exit}')
-          if [ -z "$DIGEST" ]; then
-            echo "Failed to resolve digest" >&2
-            exit 1
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          # GHCR eventual-consistency retry — see Build API for rationale.
+          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-worker:${{ github.sha }}"
+          for attempt in 1 2 3 4 5; do
+            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
+              if [ -n "$DIGEST" ]; then
+                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+                echo "Resolved worker digest on attempt ${attempt}: ${DIGEST}"
+                exit 0
+              fi
+            fi
+            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
+            sleep $((attempt * 5))
+          done
+          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
+          exit 1
           echo "Resolved worker digest: ${DIGEST}"
 
   # ===========================================================================


### PR DESCRIPTION
## Why this PR exists

CEQ Deploy has failed **5 consecutive runs** (2026-04-28 01:28 → 06:25 UTC) — all with the same error pattern:

```
ERROR: ghcr.io/madfam-org/ceq-{api,studio}:<sha>: not found
```

… occurring within ~3 seconds of cosign successfully signing the same image. The build push is fine; the digest-resolution probe is racing GHCR's eventual-consistency window.

Failed runs: \`25021407225\`, \`25028850724\`, \`25030756141\`, \`25032171848\`, \`25035787433\`.

Meanwhile prod has 1 of 3 ceq-api pods stuck in CrashLoopBackOff (3613 restarts in 12 days) — the pydantic[email] fix from PR #18 merged but never deployed because of this race.

## Root cause

`docker buildx imagetools inspect` queries GHCR's content API. After `docker buildx build --push` returns success and cosign uploads a signature, the manifest occasionally takes >3s to become visible to a fresh inspect call from the **same runner**. The single-shot inspect with `set -euo pipefail` immediately fails the job.

## Fix

Replaced the single-shot `imagetools inspect` with a 5-attempt backoff loop (5s, 10s, 15s, 20s, 25s = 75s total max wait) at all 3 build sites:

- Build API (line ~117)
- Build Studio (line ~197)
- Build Worker (line ~265)

Pattern documented at the API site; cross-referenced from Studio + Worker.

## Verification

After merge, the next push to main will trigger Deploy. Expected: `Resolved api digest on attempt 1` (or 2 if the race recurs). If Deploy fails again with a different error, the race is masked but the underlying issue is something else — investigate.

To validate fully on the existing failed runs, an operator could re-run any of the 5 failed Deploy databaseIds; GHCR has converged by now so they should pass on attempt 1.

## Scope

This PR touches **only** \`.github/workflows/deploy.yaml\` (3 step blocks, 47 insertions / 26 deletions). No application code changes. Closes #19 (CEQ Deploy stability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)