### PR TITLE
chore(k8s): pin image digests for ceq-api + ceq-studio (RFC 0017)

### DIFF
--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -38,11 +38,47 @@ resources:
 # pinning each Deployment + the migration Job to a content-addressed
 # digest. ArgoCD's `ceq-services` application reconciles the change
 # within ~3 min.
+#
+# 2026-05-03 — pinned api + studio per RFC 0017 + the 2026-05-03
+# ecosystem-health audit (Kyverno fail-closed mutable-tag policy).
+#
+# Why `newName` redirects to slash-form: the deploy.yaml workflow as
+# refactored at acecfd5 builds + pushes to `ceq-{api,studio,worker}`
+# (dash-form), but every CEQ Deploy run since acecfd5 has failed at the
+# digest-resolve step — those dash-form images have never been
+# successfully pushed to GHCR. Meanwhile, the running pods (per the
+# 2026-05-03 audit) pull `ghcr.io/madfam-org/ceq/{api,studio}:latest`
+# (slash-form), the legacy image path that was successfully built up
+# through 2026-04-28T02:33Z (pre-GitOps-refactor commit c9da2ce, run
+# 25030756141). Pinning `name` to dash-form (what the Deployment
+# manifests reference) and `newName` to slash-form (what actually
+# exists on GHCR) plus the digest redirects to the real, present-on-
+# registry image and removes the `:latest` violation in one step.
+#
+# The CEQ Deploy workflow itself is broken (dash-form push failure)
+# and is tracked separately (see ecosystem-health audit § 2 / RFC 0017
+# CI burn-down). Once the workflow is fixed and dash-form images
+# actually exist, swap `newName` back to `ceq-{api,studio}` (or just
+# delete the `newName` line — name and newName matching is the
+# kustomize default).
+#
+# `ceq-worker` is left as `:latest` because (a) it's not in the audit
+# list of running deployments — Vast.ai scheduling means workers are
+# scaled-to-zero in-cluster — and (b) no successful slash-form
+# `ceq/worker` build exists in the workflow history to source a digest
+# from. Pinning a non-existent image would break ArgoCD sync if the
+# pod ever scaled up.
+#
+# Digest provenance: `pushing manifest for ghcr.io/madfam-org/<img>:latest@sha256:…`
+# line in run 25030756141, jobs 73311672398 (api) and 73311672389 (studio),
+# 2026-04-28T02:40-46Z, commit c9da2ce.
 images:
   - name: ghcr.io/madfam-org/ceq-api
-    newTag: latest
+    newName: ghcr.io/madfam-org/ceq/api
+    digest: sha256:f36f7e0eb92865c987f929b29873391087b7a7ac785a90fbfa972f3e93271fd9
   - name: ghcr.io/madfam-org/ceq-studio
-    newTag: latest
+    newName: ghcr.io/madfam-org/ceq/studio
+    digest: sha256:05dd963559592576fb15fd6958aafd5bb9399a64475e945ae74560e678338352
   - name: ghcr.io/madfam-org/ceq-worker
     newTag: latest
 


### PR DESCRIPTION
## Summary

Pins explicit `sha256:` digests for the two CEQ production deployments flagged by the [2026-05-03 ecosystem-health audit](../../claudedocs/ECOSYSTEM_HEALTH_2026-05-03.md) as running with `:latest`-tagged images, in violation of the Kyverno fail-closed mutable-tag policy claimed by `ECOSYSTEM.md`.

| Image (manifest reference) | Old | New |
|---|---|---|
| `ghcr.io/madfam-org/ceq-api` | `:latest` | `ceq/api@sha256:f36f7e0e…` |
| `ghcr.io/madfam-org/ceq-studio` | `:latest` | `ceq/studio@sha256:05dd9635…` |
| `ghcr.io/madfam-org/ceq-worker` | `:latest` | unchanged (see worker note) |

## Why `newName` redirects to slash-form

The deploy workflow refactor at `acecfd5` switched the build/push image namespace from slash-form (`ceq/{api,studio,worker}`) to dash-form (`ceq-{api,studio,worker}`). **Every CEQ Deploy run since acecfd5 has failed** at the digest-resolve step — dash-form images have never been successfully pushed to GHCR.

Meanwhile, the cluster's running pods (per the audit) pull `ghcr.io/madfam-org/ceq/{api,studio}:latest` (slash-form, the legacy path) — these were last successfully built **2026-04-28T02:33Z** (pre-refactor commit `c9da2ce`, run [25030756141](https://github.com/madfam-org/ceq/actions/runs/25030756141)).

Kustomize's images transformer matches by `name` (what the Deployment manifest references) and substitutes `newName + digest`. Pinning to slash-form here:

- Removes the `:latest` violation immediately
- Points ArgoCD at images that **actually exist on GHCR right now**
- Doesn't require touching any deployment yaml
- Is trivially reversible once the dash-form push works (just swap `newName` back to dash-form, or delete the `newName` line — the default is name-equals-newName)

## Why `ceq-worker` is not pinned

- Not in the audit's list of running deployments — per `CLAUDE.md`, workers run on Vast.ai (scaled-to-zero in-cluster).
- No successful slash-form `ceq/worker` build exists in workflow history to source a digest from.
- Pinning a non-existent image would break ArgoCD sync if the pod ever scaled up.

## Digest provenance

The gh token in the worktree environment lacks `read:packages` scope, so `docker buildx imagetools inspect ghcr.io/madfam-org/ceq/<img>:latest` returned 403. Fell back to the canonical workflow-log source — the `pushing manifest for <image>:latest@sha256:…` line in:

| Image | Run | Job | Time |
|---|---|---|---|
| `ceq/api`    | [25030756141](https://github.com/madfam-org/ceq/actions/runs/25030756141) | 73311672398 | 2026-04-28T02:46:03Z |
| `ceq/studio` | [25030756141](https://github.com/madfam-org/ceq/actions/runs/25030756141) | 73311672389 | 2026-04-28T02:40:46Z |

Both digests are the most-recent `:latest` content for those slash-form image paths, on commit `c9da2ce` (last build before the GitOps refactor).

## Effect on the cluster

ArgoCD's `ceq-services` Application will reconcile to the slash-form digest on next sync (~3 min after merge). The running pods are already on slash-form `:latest` so this pin is the explicit forward state — no image swap, just the `:latest` → `@sha256:…` upgrade.

The CEQ Deploy workflow's broken dash-form push is separate; tracked under RFC 0017 CI burn-down + audit § 2.

## Related

- RFC 0017: [internal-devops/rfcs/0017-stabilize-main-ci.md](https://github.com/madfam-org/internal-devops/blob/main/rfcs/0017-stabilize-main-ci.md)
- Audit: `claudedocs/ECOSYSTEM_HEALTH_2026-05-03.md` § 4 "Image-tag policy drift"

## Test plan

- [ ] Reviewer runs `kustomize build infrastructure/k8s/` locally and confirms `Deployment/ceq-api` + `Deployment/ceq-studio` rendered output has `image: ghcr.io/madfam-org/ceq/{api,studio}@sha256:…` (slash-form, digest, no `:latest`)
- [ ] Worker Deployment is unchanged in the rendered output (still `ceq-worker:latest`, scaled-to-zero in cluster anyway)
- [ ] ArgoCD `ceq-services` Application syncs cleanly within ~3 min after merge
- [ ] No Kyverno PolicyViolation events for `ceq-api` or `ceq-studio`
- [ ] `kubectl -n ceq get deploy/ceq-api -o jsonpath='{.spec.template.spec.containers[0].image}'` returns digest-pinned reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)