### PR TITLE
fix(deploy): use build action's digest output instead of broken imagetools resolve

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,12 @@ jobs:
       id-token: write
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -114,31 +119,6 @@ jobs:
         run: |
           cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-api@${{ steps.build.outputs.digest }}
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # docker buildx imagetools inspect returns the manifest-list digest
-          # for multi-arch images. `docker manifest inspect | jq` returns null
-          # for multi-arch (enclii#136).
-          # GHCR has eventual-consistency between push and pull-side visibility;
-          # retry with backoff (ceq#19) — observed 5 consecutive Deploy failures
-          # 2026-04-28 on "manifest unknown" within 3s of push.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-api:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved api digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-
   # ===========================================================================
   # Build Studio Image
   # ===========================================================================
@@ -151,7 +131,12 @@ jobs:
       id-token: write
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -202,26 +187,6 @@ jobs:
         run: |
           cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-studio@${{ steps.build.outputs.digest }}
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # GHCR eventual-consistency retry — see Build API for rationale.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-studio:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved studio digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-
   # ===========================================================================
   # Build Worker Image (Optional)
   # ===========================================================================
@@ -240,7 +205,12 @@ jobs:
       contains(github.event.head_commit.modified, 'apps/workers/')
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -276,26 +246,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # GHCR eventual-consistency retry — see Build API for rationale.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-worker:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved worker digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-          echo "Resolved worker digest: ${DIGEST}"
 
   # ===========================================================================
   # GitOps Deploy: commit digests to kustomization.yaml


### PR DESCRIPTION
## Summary

CEQ Deploy has been failing on **every run since acecfd5** (PR #17 GitOps refactor, 2026-04-27) at the "Resolve manifest-list digest" step. Today's [run #25290570440](https://github.com/madfam-org/ceq/actions/runs/25290570440) hit the same wall:

\`\`\`
Attempt 1 failed — sleeping 5s before retry
Attempt 2 failed — sleeping 10s before retry
Attempt 3 failed — sleeping 15s before retry
Attempt 4 failed — sleeping 20s before retry
Attempt 5 failed — sleeping 25s before retry
Failed to resolve digest after 5 attempts (75s total)
\`\`\`

The step calls \`docker buildx imagetools inspect ghcr.io/madfam-org/ceq-{api,studio,worker}:<sha>\` with PR-#19's exponential-backoff retry to handle GHCR eventual-consistency on push. Reality: even at 75s of backoff, \`imagetools inspect\` returns nothing for the freshly-pushed image. Yet **the cosign step immediately above succeeds** — using \`steps.build.outputs.digest\` from docker/build-push-action.

## Fix

One change per build job (3 jobs: api, studio, worker):

- Remove the entire \`Resolve manifest-list digest\` shell block (~20 lines each).
- Change \`outputs.digest\` from \`\${{ steps.digest.outputs.digest }}\` to \`\${{ steps.build.outputs.digest }}\` — the same digest cosign already signs.

\`docker/build-push-action\`'s \`outputs.digest\` IS the canonical manifest-list digest (multi-arch) / image-manifest digest (single-arch). It's set after a successful push completes; using it skips the eventual-consistency wait entirely.

Net diff: −68 / +18 lines.

## Test plan

- [ ] Merge → main → CEQ Deploy triggers automatically.
- [ ] Build Studio + Build API both succeed (cosign signs the image, jobs export digest).
- [ ] "Commit digest pins" job updates \`infrastructure/k8s/kustomization.yaml\` with both digests.
- [ ] ArgoCD picks up + reconciles within ~3 min.
- [ ] \`https://ceq.lol/\` finally serves the marketing landing (currently still studio shell because previous deploys never published the fix).

## Why this matters now

Today merged ceq#20 (landing fix) and ceq#21 (image digest pins). Without this deploy fix, neither ships to prod. The 4-day-old forj-api outage was a similar "deploy pipeline silently swallowing successful builds" pattern — RFC 0017 Tier B is the architectural follow-up; this PR is the surgical unblock for ceq specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)