### PR TITLE
fix(deploy): use GITHUB_TOKEN unconditionally — MADFAM_BOT_PAT expired

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,12 @@ jobs:
       id-token: write
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -114,31 +119,6 @@ jobs:
         run: |
           cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-api@${{ steps.build.outputs.digest }}
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # docker buildx imagetools inspect returns the manifest-list digest
-          # for multi-arch images. `docker manifest inspect | jq` returns null
-          # for multi-arch (enclii#136).
-          # GHCR has eventual-consistency between push and pull-side visibility;
-          # retry with backoff (ceq#19) — observed 5 consecutive Deploy failures
-          # 2026-04-28 on "manifest unknown" within 3s of push.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-api:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved api digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-
   # ===========================================================================
   # Build Studio Image
   # ===========================================================================
@@ -151,7 +131,12 @@ jobs:
       id-token: write
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -202,26 +187,6 @@ jobs:
         run: |
           cosign sign --yes ${{ env.IMAGE_NAMESPACE }}/ceq-studio@${{ steps.build.outputs.digest }}
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # GHCR eventual-consistency retry — see Build API for rationale.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-studio:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved studio digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-
   # ===========================================================================
   # Build Worker Image (Optional)
   # ===========================================================================
@@ -240,7 +205,12 @@ jobs:
       contains(github.event.head_commit.modified, 'apps/workers/')
 
     outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+      # docker/build-push-action's `outputs.digest` IS the manifest-list
+      # digest for multi-arch and the image manifest digest for single-arch
+      # — same value cosign signs above. Reusing it avoids the broken
+      # imagetools-inspect retry that was failing on every CEQ Deploy run
+      # since acecfd5 (75s × 5 retries, then exit 1).
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
@@ -276,26 +246,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Resolve manifest-list digest
-        id: digest
-        run: |
-          set -euo pipefail
-          # GHCR eventual-consistency retry — see Build API for rationale.
-          IMAGE="${{ env.IMAGE_NAMESPACE }}/ceq-worker:${{ github.sha }}"
-          for attempt in 1 2 3 4 5; do
-            if DIGEST=$(docker buildx imagetools inspect "$IMAGE" 2>&1 | awk '/^Digest:/{print $2; exit}'); then
-              if [ -n "$DIGEST" ]; then
-                echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-                echo "Resolved worker digest on attempt ${attempt}: ${DIGEST}"
-                exit 0
-              fi
-            fi
-            echo "Attempt ${attempt} failed — sleeping $((attempt * 5))s before retry" >&2
-            sleep $((attempt * 5))
-          done
-          echo "Failed to resolve digest after 5 attempts (75s total)" >&2
-          exit 1
-          echo "Resolved worker digest: ${DIGEST}"
 
   # ===========================================================================
   # GitOps Deploy: commit digests to kustomization.yaml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -270,7 +270,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
+          # NOTE 2026-05-03: MADFAM_BOT_PAT was expired and the
+          # `secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN` fallback
+          # silently failed (a non-empty expired string is still truthy
+          # so the `||` never reached the fallback). Use GITHUB_TOKEN
+          # directly until the bot PAT is rotated. The job's
+          # `permissions: contents: write` block grants the token push
+          # access; the only cosmetic side-effect is commits show as
+          # `github-actions[bot]` instead of `madfam-deploy-bot`.
+          # Re-enable bot attribution later by reverting this hunk.
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Install kustomize


### PR DESCRIPTION
## Summary

Today's [CEQ Deploy run 25291127869](https://github.com/madfam-org/ceq/actions/runs/25291127869) finally cleared the digest-resolve fix ([#22](https://github.com/madfam-org/ceq/pull/22)) — both Build API + Build Studio succeeded for the first time since acecfd5. **But the GitOps "Commit deploy digests" job then failed at \`actions/checkout@v4\`**:

\`\`\`
fatal: could not read Username for 'https://github.com':
        terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
\`\`\`

## Root cause

\`secrets.MADFAM_BOT_PAT\` is configured but the underlying fine-grained PAT has **expired**. The conditional fallback:

\`\`\`yaml
token: \${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

doesn't trigger the fallback because GitHub Actions expressions treat any non-empty string as truthy — so an expired-but-non-empty PAT value short-circuits the \`||\`. Token gets passed, GitHub rejects it, fetch falls back to interactive prompt (which doesn't exist on a runner), exit 128.

## Fix

Use \`GITHUB_TOKEN\` directly. The job's \`permissions: contents: write\` block already grants the auto-injected token push access to main. The only side-effect is commits show as \`github-actions[bot]\` instead of \`madfam-deploy-bot\` — purely cosmetic.

## Operator follow-up

To restore bot attribution:
1. Generate a fresh fine-grained PAT (or classic with \`repo\` scope) on the \`madfam-deploy-bot\` account
2. Update repo secret \`MADFAM_BOT_PAT\`
3. Revert this PR's hunk to restore the conditional

## Why this matters now

This is the FOURTH fix in the chain to unblock CEQ's GitOps loop:
- ceq#20 — landing fix (the actual code change)
- ceq#21 — digest pin in active manifest dir
- ceq#22 — replace broken \`imagetools inspect\` with build action's digest output
- **ceq#23 — this PR — bot token fallback**

Each was a real, separate bug in the deploy pipeline. After this lands, the next CEQ Deploy run should fully succeed: Build API ✓, Build Studio ✓, Commit digests ✓ → ArgoCD picks up → ceq.lol finally serves the marketing landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)