### PR TITLE
fix(k8s): add securityContext to ceq-db-migrate to satisfy Kyverno

### DIFF
--- a/infrastructure/k8s/db-migrate-job.yaml
+++ b/infrastructure/k8s/db-migrate-job.yaml
@@ -32,9 +32,22 @@ spec:
         component: migration
     spec:
       restartPolicy: Never
+      # Pod-level security context matches studio-deployment.yaml so this
+      # Job passes the cluster's Kyverno policies. Without it, ArgoCD sync
+      # is blocked by `restrict-capabilities` + `block-host-ports`.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: migrate
           image: ghcr.io/madfam-org/ceq-api:latest
+          # Explicit empty ports list — autogen-deny-host-ports rule
+          # evaluates a concrete shape; an absent ports field tripped
+          # the policy in this cluster's autogen variant.
+          ports: []
           command:
             - /bin/sh
             - -c
@@ -61,3 +74,8 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]


### PR DESCRIPTION
## Summary

ArgoCD sync of \`ceq-services\` is currently blocked at the PreSync hook by Kyverno admission webhook:

\`\`\`
Job/ceq/ceq-db-migrate was blocked due to the following policies:
  block-host-ports/autogen-deny-host-ports: hostPort is forbidden...
  restrict-capabilities/autogen-drop-all-capabilities: Containers should drop ALL capabilities
\`\`\`

The Job had no Pod-level or container-level securityContext, so the cluster's Kyverno policies (which auto-generate equivalent rules for Pod-controlling resources) flagged it.

## Fix

Align with the pattern \`studio-deployment.yaml\` already uses successfully:

- Pod-level: \`runAsNonRoot\`, \`runAsUser: 1001\`, \`fsGroup: 1001\`, \`seccompProfile: RuntimeDefault\`
- Container-level: \`privileged: false\`, \`allowPrivilegeEscalation: false\`, \`capabilities.drop: [ALL]\`
- Explicit empty \`ports: []\` so \`autogen-deny-host-ports\` evaluates a concrete shape

## Why this matters now

This is the *fifth* fix in today's chain to actually get the ceq.lol marketing landing into prod:

1. ceq#20 — landing fix (the actual code change)
2. ceq#21 — image digest pins in active manifest dir
3. ceq#22 — replace broken \`imagetools inspect\` with build-action digest
4. ceq#23 — bot token fallback (expired PAT)
5. enclii#192 — ArgoCD manifestPath: infra/k8s/production → infrastructure/k8s
6. **ceq#24 — this PR — Kyverno securityContext compliance**

Each was a real, separate bug. The first four were build/deploy pipeline; #5 was an ArgoCD config drift after I deleted the stale path; #6 is a Kyverno policy that the new manifests didn't account for.

After this lands and ArgoCD finishes one clean sync, ceq.lol should finally serve the marketing landing.

## Test plan

- [ ] Merge → ArgoCD's next sync attempt succeeds at PreSync hook
- [ ] db-migrate Job runs alembic upgrade head, succeeds
- [ ] ceq-studio Deployment rolls to dash-form digest
- [ ] \`https://ceq.lol/\` serves marketing landing (Wrestle order from chaos…)
- [ ] \`https://ceq.lol/landing\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)