### PR TITLE
fix(k8s): add enclii.dev namespace labels — exempts ceq from framework policies

### DIFF
--- a/infrastructure/k8s/namespace.yaml
+++ b/infrastructure/k8s/namespace.yaml
@@ -4,4 +4,14 @@ metadata:
   name: ceq
   labels:
     app.kubernetes.io/name: ceq
-    app.kubernetes.io/part-of: madfam
+    app.kubernetes.io/part-of: madfam-platform
+    # Enclii namespace classification — exempts the namespace from the
+    # cluster's "framework" Kyverno policies (block-host-ports,
+    # block-latest-ifnotpresent, require-health-probes, etc.) which are
+    # designed for opt-in production application namespaces. Every other
+    # active product namespace (fortuna, karafiel, dhanam, etc.) carries
+    # these labels; ceq was the only one missing them, which is why
+    # ArgoCD sync hit `validate.kyverno.svc-fail` repeatedly on
+    # 2026-05-03 even after manifest-level securityContext fixes.
+    enclii.dev/type: application
+    enclii.dev/data-access: "true"


### PR DESCRIPTION
## Root cause

The ceq namespace was missing two labels every other active product namespace carries:

\`\`\`yaml
enclii.dev/type: application
enclii.dev/data-access: "true"
\`\`\`

Cross-checked against fortuna, karafiel, dhanam — all three have both labels. ceq alone was missing them.

## Why it matters

Each cluster Kyverno policy is scoped to NOT apply when these labels exist:

\`\`\`yaml
exclude:
  namespaceSelector:
    matchExpressions:
    - key: enclii.dev/type
      operator: Exists
\`\`\`

Without the label, ceq's manifests trip the framework policies:
- `block-host-ports` — fired even on Jobs with no ports
- `block-latest-ifnotpresent` — would fire on \`:latest\` tags
- `require-health-probes` — would fire on one-shot batch jobs
- ...etc

This was the *real* root cause of today's ArgoCD sync failures, not the per-manifest securityContext gaps. ceq#24 was correct (the `restrict-capabilities` baseline IS universal), but the framework policies are namespace-opt-in via the labels.

## Net result

After this lands and ArgoCD finishes one clean sync, the long cascade today completes:

1. ceq#20 — landing fix code
2. ceq#21 — image digest pin manifest
3. ceq#22 — deploy.yaml `imagetools inspect` → build digest
4. ceq#23 — bot token expired → GITHUB_TOKEN
5. enclii#192 — ArgoCD `infra/k8s/production` → `infrastructure/k8s`
6. ceq#24 — db-migrate-job securityContext (restrict-capabilities)
7. **ceq#25 — this PR — namespace labels (the framework-policy gate)**

## Test plan

- [ ] Merge → ApplicationSet/ArgoCD reconcile applies the namespace patch
- [ ] Subsequent sync passes Kyverno admission
- [ ] db-migrate Job runs alembic, deployment rolls
- [ ] \`https://ceq.lol/\` renders \`<MarketingLanding />\`, \`/landing\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)