### PR TITLE
fix(k8s): add imagePullSecrets to ceq-db-migrate

### DIFF
--- a/infrastructure/k8s/db-migrate-job.yaml
+++ b/infrastructure/k8s/db-migrate-job.yaml
@@ -32,6 +32,12 @@ spec:
         component: migration
     spec:
       restartPolicy: Never
+      # GHCR pull credentials — the ceq-api image at the dash-form
+      # registry path is private; without imagePullSecrets the pod
+      # gets 401 from ghcr.io/token. studio-deployment.yaml uses the
+      # same secret.
+      imagePullSecrets:
+        - name: ghcr-credentials
       # Pod-level security context matches studio-deployment.yaml so this
       # Job passes the cluster's Kyverno policies. Without it, ArgoCD sync
       # is blocked by `restrict-capabilities` + `block-host-ports`.


### PR DESCRIPTION
## Summary

After the namespace labels ([#25](https://github.com/madfam-org/ceq/pull/25)) freed Kyverno admission, the migration Pod's actual containers tried to pull \`ghcr.io/madfam-org/ceq-api@sha256:55f152...\` (the new dash-form digest from today's deploys) and got 401:

\`\`\`
failed to fetch anonymous token: unexpected status from GET request to
  https://ghcr.io/token?scope=repository%3Amadfam-org%2Fceq-api%3Apull
  : 401 Unauthorized
\`\`\`

The dash-form image is private. \`studio-deployment.yaml\` already had \`imagePullSecrets: [ghcr-credentials]\`; \`db-migrate-job.yaml\` was missing it.

## Test plan
- [ ] Merge → ArgoCD reapplies the Job spec → Pod successfully pulls → alembic upgrade head runs → succeeds → PreSync hook completes → ceq-studio + ceq-api Deployments roll to dash-form digests → ceq.lol serves marketing landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)