### PR TITLE
fix(k8s): commit NetworkPolicies — unblocks cloudflared → ceq pods

### DIFF
--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
 - studio-deployment.yaml
 - worker-deployment.yaml
 - db-migrate-job.yaml
+- network-policies.yaml
   # cloudflared removed 2026-04-25: ceq-prod tunnel deleted on Cloudflare side
   # 2026-04-09; ceq.lol / api.ceq.lol / ws.ceq.lol DNS now routes through the
   # main enclii-prod tunnel at the platform level. No per-namespace cloudflared

--- a/infrastructure/k8s/network-policies.yaml
+++ b/infrastructure/k8s/network-policies.yaml
@@ -1,0 +1,81 @@
+# CEQ NetworkPolicies
+#
+# Allow rules layered on top of the enclii-onboarding default-deny.
+# Without these, cloudflared cannot reach ceq pods (default-deny blocks
+# all ingress + egress except port 53). Pattern matches fortuna namespace.
+#
+# Applied directly via kubectl on 2026-05-03 to unblock the ceq.lol
+# marketing-landing rollout; committed to git so future ArgoCD reconciles
+# preserve them.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared-ingress
+  namespace: ceq
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cloudflare-tunnel
+    ports:
+    - port: 5800
+      protocol: TCP
+    - port: 5801
+      protocol: TCP
+    - port: 8000
+      protocol: TCP
+    - port: 80
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: ceq
+spec:
+  egress:
+  - to:
+    - podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-https-egress
+  namespace: ceq
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 80
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-data-egress
+  namespace: ceq
+spec:
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: data
+  podSelector: {}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
## TL;DR

ceq's namespace had a \`default-deny\` NetworkPolicy installed by enclii onboarding 25 days ago, but the matching allow rules (which fortuna/karafiel/dhanam all carry) were never added for ceq. cloudflared therefore couldn't reach any ceq pod; ceq.lol kept returning 502 even with healthy pods running the new dash-form image.

This PR commits the 4 allow rules — applied directly to the cluster on 2026-05-03 to unblock the rollout — to git, so future ArgoCD reconciles preserve them.

## Verification (post-apply)

| Surface | Status |
|---|---|
| \`https://ceq.lol/\` (marketing landing) | **200** |
| \`https://ceq.lol/landing\` | **200** |
| \`https://app.ceq.lol/\` | **200** |
| \`https://api.ceq.lol/health\` | **200** |

## NetworkPolicies added

- \`allow-cloudflared-ingress\` — cloudflared → ceq pods (ports 80, 5800, 5801, 8000)
- \`allow-intra-namespace\` — ceq pod ↔ ceq pod
- \`allow-https-egress\` — ceq pod → external HTTPS (selva, GHCR, etc.)
- \`allow-data-egress\` — ceq pod → data namespace (postgres, redis)

Pattern modeled exactly on fortuna's namespace.

## The full cascade today (for the audit trail)

This is the 8th PR in today's chain to actually deliver ceq.lol's marketing landing. Each fix unblocked the next layer:

1. ceq#20 — landing-fix code (route + middleware)
2. ceq#21 — image digest pin manifest
3. ceq#22 — deploy.yaml: \`imagetools inspect\` → build digest
4. ceq#23 — bot token: PAT expired → GITHUB_TOKEN
5. enclii#192 — ArgoCD manifestPath: \`infra/k8s/production\` → \`infrastructure/k8s\`
6. ceq#24 — db-migrate-job securityContext
7. ceq#25 — namespace \`enclii.dev/*\` labels (Kyverno framework exemption)
8. ceq#26 — db-migrate-job imagePullSecrets
9. ceq#27 — db-migrate-job UPPER_CASE secret keys
10. **ceq#28 — this PR — NetworkPolicies**

🤖 Generated with [Claude Code](https://claude.com/claude-code)