### PR TITLE
fix(k8s): NetworkPolicies + Kyverno-compliant worker + service port alignment

### DIFF
--- a/infrastructure/k8s/api-deployment.yaml
+++ b/infrastructure/k8s/api-deployment.yaml
@@ -70,7 +70,8 @@ spec:
   selector:
     app: ceq-api
   ports:
-    - port: 5800
+    - name: http
+      port: 80
       targetPort: 5800
-      name: http
+      protocol: TCP
   type: ClusterIP

--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
 - studio-deployment.yaml
 - worker-deployment.yaml
 - db-migrate-job.yaml
+- network-policies.yaml
   # cloudflared removed 2026-04-25: ceq-prod tunnel deleted on Cloudflare side
   # 2026-04-09; ceq.lol / api.ceq.lol / ws.ceq.lol DNS now routes through the
   # main enclii-prod tunnel at the platform level. No per-namespace cloudflared

--- a/infrastructure/k8s/network-policies.yaml
+++ b/infrastructure/k8s/network-policies.yaml
@@ -1,0 +1,81 @@
+# CEQ NetworkPolicies
+#
+# Allow rules layered on top of the enclii-onboarding default-deny.
+# Without these, cloudflared cannot reach ceq pods (default-deny blocks
+# all ingress + egress except port 53). Pattern matches fortuna namespace.
+#
+# Applied directly via kubectl on 2026-05-03 to unblock the ceq.lol
+# marketing-landing rollout; committed to git so future ArgoCD reconciles
+# preserve them.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared-ingress
+  namespace: ceq
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cloudflare-tunnel
+    ports:
+    - port: 5800
+      protocol: TCP
+    - port: 5801
+      protocol: TCP
+    - port: 8000
+      protocol: TCP
+    - port: 80
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: ceq
+spec:
+  egress:
+  - to:
+    - podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-https-egress
+  namespace: ceq
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 80
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-data-egress
+  namespace: ceq
+spec:
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: data
+  podSelector: {}
+  policyTypes:
+  - Egress

--- a/infrastructure/k8s/studio-deployment.yaml
+++ b/infrastructure/k8s/studio-deployment.yaml
@@ -71,7 +71,8 @@ spec:
   selector:
     app: ceq-studio
   ports:
-    - port: 5801
+    - name: http
+      port: 80
       targetPort: 5801
-      name: http
+      protocol: TCP
   type: ClusterIP

--- a/infrastructure/k8s/worker-deployment.yaml
+++ b/infrastructure/k8s/worker-deployment.yaml
@@ -23,9 +23,16 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: ceq-worker
           image: ghcr.io/madfam-org/ceq-worker:latest
+          ports: []
           env:
             - name: WORKER_ID
               valueFrom:
@@ -35,7 +42,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: ceq-secrets
-                  key: redis-url
+                  key: REDIS_URL
             - name: COMFYUI_PATH
               value: /opt/comfyui
             - name: MODELS_PATH
@@ -51,6 +58,11 @@ spec:
               memory: "32Gi"
               cpu: "8"
               nvidia.com/gpu: "1"
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           volumeMounts:
             - name: models
               mountPath: /opt/models


### PR DESCRIPTION
## Summary

Three coupled fixes that unblock ceq-services in ArgoCD:

1. **NetworkPolicies** (5ab2a86, prior commit on this branch): add allow rules on top of the namespace's default-deny so cloudflared can reach the api/studio/worker pods. Without this, ceq.lol returned 502 even with healthy pods.

2. **Service port alignment** (this commit): live cluster runs `port: 80 → targetPort: 5800/5801` (manually patched during the cloudflared work earlier this month) but the source still declared `port: 5800/5801`. ArgoCD's client-side-apply migration was failing with `spec.ports[0].name: Required value`. Source now matches live shape.

3. **ceq-worker securityContext** (this commit): GPU worker had no securityContext at all → Kyverno's `restrict-capabilities` rejected every apply attempt. Added pod-level `runAsNonRoot`, `runAsUser:1001`, `fsGroup:1001`, `seccompProfile`, plus container-level `privileged:false`, `allowPrivilegeEscalation:false`, `capabilities.drop:[ALL]`. Also fixed REDIS_URL to UPPER_CASE (matches #27 pattern) and added explicit `ports: []`.

After this, ceq-services should reach Synced+Healthy in ArgoCD on next reconcile.

## Test plan

- [x] Live api/studio/worker pods continue running 2/2 Ready
- [x] cloudflared still reaches them (NetworkPolicies were already live before this commit)
- [ ] Post-merge: verify ArgoCD ceq-services reaches Synced+Healthy
- [ ] Post-merge: confirm ceq-worker can apply (won't actually schedule — replicas=0 + GPU node selector — but the manifest must validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)