### PR TITLE
feat(security): allow Selva Atrium to iframe this app via CSP frame-ancestors

### DIFF
--- a/apps/api/src/ceq_api/middleware.py
+++ b/apps/api/src/ceq_api/middleware.py
@@ -135,13 +135,24 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         # Security headers
+        # X-Frame-Options downgraded from DENY to SAMEORIGIN as a legacy fallback
+        # for the Selva Atrium iframe pattern; modern browsers honor frame-ancestors.
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
 
         # Content Security Policy for API
-        response.headers["Content-Security-Policy"] = "default-src 'none'; frame-ancestors 'none'"
+        # frame-ancestors permits the Selva Atrium (selva-office consumer feature)
+        # to embed CEQ surfaces. Same operator (Innovaciones MADFAM) on both sides.
+        # Note: api.ceq.lol primarily returns JSON; the Atrium would only iframe
+        # the studio (ceq.lol), but the FastAPI app also serves the OpenAPI docs +
+        # render endpoints which are reachable as HTML/binary, so we keep the
+        # policy app-wide for consistency.
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'none'; "
+            "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io"
+        )
 
         # Prevent caching of sensitive data
         if request.url.path.startswith("/v1/"):

--- a/apps/api/tests/test_middleware.py
+++ b/apps/api/tests/test_middleware.py
@@ -57,10 +57,10 @@ class TestSecurityHeadersMiddleware:
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
 
     def test_frame_options(self, client):
-        """Should include X-Frame-Options header."""
+        """Should include X-Frame-Options header (SAMEORIGIN — legacy fallback for Atrium)."""
         response = client.get("/health")
 
-        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
 
     def test_xss_protection(self, client):
         """Should include X-XSS-Protection header."""
@@ -75,11 +75,16 @@ class TestSecurityHeadersMiddleware:
         assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
 
     def test_content_security_policy(self, client):
-        """Should include Content-Security-Policy header."""
+        """Should include Content-Security-Policy header with Selva Atrium allowance."""
         response = client.get("/health")
 
         csp = response.headers.get("Content-Security-Policy", "")
         assert "default-src 'none'" in csp
+        # Selva Atrium (selva-office consumer feature) is allowed to iframe.
+        assert "frame-ancestors" in csp
+        assert "https://selva.town" in csp
+        assert "https://*.selva.town" in csp
+        assert "https://*.madfam.io" in csp
 
     def test_cache_control_for_api(self, client):
         """API endpoints should have no-cache headers."""

--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -38,6 +38,27 @@ const nextConfig = {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:5800",
     NEXT_PUBLIC_WS_URL: process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:5820",
   },
+  // Selva Atrium iframe allowance.
+  // The Atrium is the consumer-side feature in selva-office that surfaces every
+  // MADFAM platform as a window into a single welcoming central space. Permitting
+  // selva.town as a frame-ancestor lets the Atrium embed ceq.lol. X-Frame-Options:
+  // SAMEORIGIN remains as a legacy fallback. App-wide; auth surfaces inherit the
+  // same policy. Acceptable because Innovaciones MADFAM runs both Selva and CEQ.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          {
+            key: "Content-Security-Policy",
+            value:
+              "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds Selva Atrium (selva-office consumer feature) to `frame-ancestors` on both CEQ surfaces:

| Surface | Source of truth | Change |
|---|---|---|
| API (`api.ceq.lol`) | `apps/api/src/ceq_api/middleware.py` (`SecurityHeadersMiddleware`) | CSP `frame-ancestors 'none'` → Atrium allowance, `X-Frame-Options DENY` → `SAMEORIGIN` |
| Studio (`ceq.lol`) | `apps/studio/next.config.mjs` (`headers()`) | new — emits matching CSP + `X-Frame-Options SAMEORIGIN` |
| Contract tests | `apps/api/tests/test_middleware.py` | updated to assert the Atrium allowance |

CSP value:

```
frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io
```

The API mostly returns JSON, but FastAPI also serves OpenAPI docs + render-pipeline endpoints (`/v1/render/*`) which can produce HTML/binary; keeping the policy app-wide is the safer default.

## Auth-path clickjacking note

CSP is app-wide rather than path-scoped. `/auth/callback`, etc., inherit the same `frame-ancestors`. Acceptable because Innovaciones MADFAM operates both Selva and CEQ.

## Test plan

- [ ] `pytest apps/api/tests/test_middleware.py -v` green
- [ ] CI green (lint + typecheck + unit)
- [ ] Smoke: deploy preview, hit `/` and verify response headers include `Content-Security-Policy` with `selva.town` listed
- [ ] Atrium iframe smoke from selva.town

**DO NOT MERGE** — coordinated rollout with selva-office Atrium build.