### PR TITLE
auth: support Janua userinfo introspection fallback

### DIFF
--- a/apps/api/src/ceq_api/auth/janua.py
+++ b/apps/api/src/ceq_api/auth/janua.py
@@ -207,30 +207,56 @@ def get_janua_client() -> httpx.AsyncClient:
 
 
 async def _validate_token_introspection(token: str) -> JanuaUser | None:
-    """Validate token via Janua introspection endpoint (GET /api/v1/auth/me).
+    """Validate token via Janua userinfo/introspection endpoints.
 
-    This is the legacy validation method. It makes a network call on every
-    request (~50-200ms). Kept as a fallback when JWKS is unavailable.
+    Janua-compatible behavior is to expose user details at
+    ``/api/v1/oauth/userinfo``. ``/api/v1/auth/me`` is retained as a
+    compatibility fallback for environments still emitting the legacy endpoint.
+
+    This fallback is network-bound (~50-200ms), so it only runs when JWKS is
+    unavailable.
     """
     client = get_janua_client()
-    response = await client.get(
-        "/api/v1/auth/me",
-        headers={"Authorization": f"Bearer {token}"},
-    )
+    headers = {"Authorization": f"Bearer {token}"}
+    endpoints = ("/api/v1/oauth/userinfo", "/api/v1/auth/me")
 
-    if response.status_code != 200:
-        logger.debug(f"Introspection validation failed: status {response.status_code}")
-        return None
+    for endpoint in endpoints:
+        response = await client.get(endpoint, headers=headers)
+        if response.status_code != 200:
+            logger.debug(
+                "Introspection endpoint %s returned status %s", endpoint, response.status_code
+            )
+            continue
 
-    data = response.json()
-    user = JanuaUser(
-        id=UUID(data["id"]),
-        email=data["email"],
-        org_id=UUID(data["org_id"]) if data.get("org_id") else None,
-        roles=data.get("roles"),
-    )
-    logger.debug(f"Token validated via introspection for user {user.email}")
-    return user
+        data = response.json()
+        user_id = data.get("id") or data.get("sub")
+        email = data.get("email")
+        if not user_id or not email:
+            logger.debug("Introspection response missing required fields: %s", data)
+            return None
+
+        roles_raw = data.get("roles")
+        if roles_raw is None:
+            roles_raw = data.get("role")
+
+        roles: list[str] | None = None
+        if roles_raw is not None:
+            if isinstance(roles_raw, list):
+                roles = roles_raw
+            elif isinstance(roles_raw, str):
+                roles = [roles_raw]
+
+        user = JanuaUser(
+            id=UUID(user_id),
+            email=email,
+            org_id=UUID(data["org_id"]) if data.get("org_id") else None,
+            roles=roles,
+        )
+        logger.debug("Token validated via introspection for user %s", user.email)
+        return user
+
+    logger.debug("Token introspection did not validate against any endpoint")
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/CEQ_STABILITY_ROADMAP.md
+++ b/docs/CEQ_STABILITY_ROADMAP.md
@@ -171,7 +171,7 @@ and `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`.
 | Priority | Category | Action | Status | Evidence status |
 |----------|----------|--------|--------|----------------|
 | P0-1 | Identity | Browser login on `app.ceq.lol` with operator credentials proves Studio shell session bootstrap. | Complete | `/api/auth/session` user payload and `httpOnly` session cookies captured |
-| P0-2 | Runtime | `GET /v1/operations/status` passes with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`) . | Not started | Not yet captured |
+| P0-2 | Runtime | `GET /v1/operations/status` passes with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`) . | In progress | PR #38 updates Janua introspection fallback endpoints. Awaiting prod verification after merge to `main`. |
 | P0-3 | Runtime | Authenticated GPU smoke and gallery durability (`job → callback → output`) | Not started | Not yet captured |
 | P0-4 | Platform | Template catalog seeded (`/v1/templates/` returns non-empty IDs) | Inconsistent | Public evidence currently empty |
 | P0-5 | Stability | Cancel + multi-modal + strict smoke pass in production | Not started | Not yet captured |
@@ -189,7 +189,7 @@ the commercial GA plan and evidence audit.
 | Priority | Action | Status | Completion rule |
 |----------|--------|--------|-----------------|
 | P0-1 | Browser login on `app.ceq.lol` with operator credentials and stable session proof. | Complete | Login succeeds + `/api/auth/session` returns user identity |
-| P0-2 | `GET /v1/operations/status` with admin JWT returns callback/webhook readiness and migration revision. | Not started | Status includes `callback.ready=true`, `webhook.ready=true`, `revision` value |
+| P0-2 | `GET /v1/operations/status` with admin JWT returns callback/webhook readiness and migration revision. | In progress | PR #38 updates API Janua introspection path. Awaiting prod verification. |
 | P0-3 | Authenticated production GPU smoke and gallery durability check. | Not started | End-to-end output URL + callback row + PostgreSQL output row |
 | P0-4 | Seed templates + persistent template IDs in production. | Inconsistent | `GET /v1/templates/` returns non-empty templates for smoke |
 | P1-1 | Strict smoke pass (`CEQ_STRICT_SMOKE=true`), dead-letter thresholds, and rollback/alarm drill proof. | Not started | Smoke script passes with documented alert + on-call path references |

--- a/docs/CEQ_STABILITY_ROADMAP.md
+++ b/docs/CEQ_STABILITY_ROADMAP.md
@@ -1,7 +1,7 @@
 # CEQ Stability Roadmap and Remediation Plan
 
 > **Last updated:** 2026-06-01
-> **Status:** Identity wiring deployed; Studio token route accepts Janua client secret; browser proof and GPU production smokes remain open
+> **Status:** Identity wiring deployed; Studio token route accepts Janua client secret; browser proof captured, GPU production smokes remain open
 > **Session wrap-up:** [`docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md`](./CEQ_IDENTITY_AND_DEMO_WRAPUP.md)  
 > **Capped GA demo:** [`docs/GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md)  
 > **Commercial GA:** [`docs/COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md)
@@ -82,7 +82,8 @@ latent chaos → shipped content.
 
 **Infra-stable, user-incomplete.** Janua OAuth client is registered and the
 deployed Studio token route accepts the Janua client secret. Browser login with
-real credentials, template seeding, and GPU production smokes still need operator
+real credentials is now proven through `/api/auth/session` and `httpOnly`
+session cookies. Template seeding and GPU production smokes still need operator
 proof before CEQ can be declared fully healthy.
 
 Commercial GA readiness remains ~47% (evidence-weighted) and is tracked as the
@@ -105,7 +106,8 @@ Use the GA-critical board below for close-form status and the evidence audit for
 | `GET /v1/templates/` | 200 JSON | `{"templates": [], "total": 0, "skip": 0, "limit": 50}` |
 | `GET /v1/credits/balance` (no auth) | 404 | Route not currently routable in public prod check |
 | `GET /v1/operations/status` (no auth) | 401 | Expected for admin-only endpoint |
-| `POST app.ceq.lol/api/auth/token` with bogus code | Janua `invalid_grant` | Client secret accepted; browser proof still pending |
+| `POST app.ceq.lol/api/auth/token` with bogus code | Janua `invalid_grant` | Client secret accepted |
+| `GET /api/auth/session` (admin credentials) | 200 JSON | `user`, `roles`, and `access_token` returned; `ceq_access_token` / `ceq_refresh_token` cookies present |
 
 ### What is working
 
@@ -147,7 +149,7 @@ historical record.
 
 ### What blocks full stability
 
-1. ~~Janua OAuth client unregistered~~ and ~~Studio token secret missing~~ → **Remaining identity proof:** browser login with real credentials
+1. ~~Janua OAuth client unregistered~~ and ~~Studio token secret missing~~ → **Remaining identity proof:** template seeding and GPU production smokes
 2. Production runtime secrets not verified live (`JOB_COMPLETION_CALLBACK_TOKEN`,
    `JOB_WEBHOOK_SECRET`)
 3. Authenticated GPU E2E, cancellation, and multi-modal smoke not proven in prod
@@ -168,7 +170,7 @@ and `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`.
 
 | Priority | Category | Action | Status | Evidence status |
 |----------|----------|--------|--------|----------------|
-| P0-1 | Identity | Browser login on `app.ceq.lol` with operator credentials proves Studio shell session bootstrap. | Blocked | Missing |
+| P0-1 | Identity | Browser login on `app.ceq.lol` with operator credentials proves Studio shell session bootstrap. | Complete | `/api/auth/session` user payload and `httpOnly` session cookies captured |
 | P0-2 | Runtime | `GET /v1/operations/status` passes with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`) . | Not started | Not yet captured |
 | P0-3 | Runtime | Authenticated GPU smoke and gallery durability (`job → callback → output`) | Not started | Not yet captured |
 | P0-4 | Platform | Template catalog seeded (`/v1/templates/` returns non-empty IDs) | Inconsistent | Public evidence currently empty |
@@ -186,7 +188,7 @@ the commercial GA plan and evidence audit.
 
 | Priority | Action | Status | Completion rule |
 |----------|--------|--------|-----------------|
-| P0-1 | Browser login on `app.ceq.lol` with operator credentials and stable session proof. | Blocked | Login succeeds + `/api/auth/session` returns user identity |
+| P0-1 | Browser login on `app.ceq.lol` with operator credentials and stable session proof. | Complete | Login succeeds + `/api/auth/session` returns user identity |
 | P0-2 | `GET /v1/operations/status` with admin JWT returns callback/webhook readiness and migration revision. | Not started | Status includes `callback.ready=true`, `webhook.ready=true`, `revision` value |
 | P0-3 | Authenticated production GPU smoke and gallery durability check. | Not started | End-to-end output URL + callback row + PostgreSQL output row |
 | P0-4 | Seed templates + persistent template IDs in production. | Inconsistent | `GET /v1/templates/` returns non-empty templates for smoke |
@@ -206,9 +208,9 @@ Engineering work landed in-repo (operator-only P0 items remain open):
 | **Phase 5** | WebSocket auth via session bootstrap | ✅ `resolveStreamAuthToken()` + async `subscribeToJob()` |
 | **Phase 6** | `ECOSYSTEM.md` drift fix | ✅ Ports, render status, Janua auth note |
 | **Phase 0** | Janua OAuth client registration | ✅ Janua registered 2026-05-23; CEQ secret mount in `studio-deployment.yaml` |
-| **Phase 0** | Studio token secret + browser proof | ⏳ Token route proof green; browser proof still operator-owned — [`JANUA_OPERATOR.md`](./JANUA_OPERATOR.md) §1–4 |
+| **Phase 0** | Studio token secret + browser proof | ✅ Token route proof green; browser proof captured via `/api/auth/session` |
 | **Phase 1** | Production callback/webhook secrets | ⏳ Operator — verify via `operations/status` |
-| **Phase 2** | Authenticated GPU smokes | ⏳ Blocked on Phase 0 + 1 |
+| **Phase 2** | Authenticated GPU smokes | ⏳ Blocked on Phase 1 |
 | **Phase 4** | Studio Docker regression CI gate | ✅ Closed 2026-05-22 |
 | **Phase 4** | GitHub branch protection on `main` | ✅ Enabled 2026-06-01; requires six CEQ CI checks + one review |
 | **Phase 4** | Playwright auth E2E in CI | ✅ 6/6 green locally (`mock-janua-server` + `next dev`; middleware allows `127.0.0.1`) |
@@ -221,7 +223,7 @@ Engineering work landed in-repo (operator-only P0 items remain open):
 | K8s `JANUA_CLIENT_SECRET` mount | ✅ Manifest on `main` |
 | CI (API/workers ruff + Studio gates) | ✅ Green |
 | Studio token secret accepted | ✅ Live token route proof (`invalid_grant` for bogus code, 2026-06-01) |
-| Browser login acceptance | ⏳ Operator — Agent 3 |
+| Browser login acceptance | ✅ `/api/auth/session` verified with user identity and `httpOnly` cookies |
 | Session wrap-up doc | ✅ [`CEQ_IDENTITY_AND_DEMO_WRAPUP.md`](./CEQ_IDENTITY_AND_DEMO_WRAPUP.md) |
 
 ## Definition of done — full stability
@@ -354,10 +356,10 @@ Record adapter gap if raw Janua admin is used.
    - Redeploy Studio via GitOps if client ID changes
 
 3. **Browser acceptance checklist**
-   - [ ] No-cookie `https://app.ceq.lol/` → `/login?returnTo=%2F`
-   - [ ] Janua login succeeds (no `invalid_client`)
-   - [ ] `/auth/callback` sets httpOnly CEQ session cookies
-   - [ ] `GET /api/auth/session` bootstraps Studio browser state
+   - [x] No-cookie `https://app.ceq.lol/` → `/login?returnTo=%2F`
+   - [x] Janua login succeeds (no `invalid_client`)
+   - [x] `/auth/callback` sets httpOnly CEQ session cookies
+   - [x] `GET /api/auth/session` bootstraps Studio browser state
    - [ ] Token refresh rotates cookies correctly
    - [ ] Logout clears CEQ cookies before Janua logout redirect
    - [ ] Studio API calls succeed via `/api/proxy`
@@ -816,7 +818,7 @@ app gate on `app.ceq.lol`.
 
 ## Immediate next actions (this week)
 
-1. [ ] **BLOCKED** **CEQ operator:** Complete real browser login proof for `app.ceq.lol` — *critical path*
+1. [x] **DONE** **CEQ operator:** Complete real browser login proof for `app.ceq.lol` — *critical path*
 2. [ ] **BLOCKED** **Platform operator:** Provision `JOB_COMPLETION_CALLBACK_TOKEN` +
    `JOB_WEBHOOK_SECRET` via Enclii/ExternalSecret
 3. [ ] **BLOCKED** **CEQ operator:** Run `operations/status` smoke with admin JWT

--- a/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
+++ b/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
@@ -66,7 +66,7 @@ Use this registry as the canonical closure board for GA-blocking work.
 | Priority | Action | Owner | Status | Completion signal |
 |----------|--------|-------|--------|------------------|
 | P0-1 | Capture real browser login proof on `app.ceq.lol` with authenticated session bootstrap (`/api/auth/session`, httpOnly cookies, Studio shell load). | Studio + Janua operator | **Complete** | `2026-06-01`: `GET /api/auth/session` returned `user`, `roles`, and `access_token` for `admin@madfam.io`; `ceq_access_token` + `ceq_refresh_token` cookies were present and `httpOnly`; Studio shell route was loaded. |
-| P0-2 | Run `GET /v1/operations/status` with admin JWT and capture callback/webhook/migration/dead-letter readiness. | Platform + API | **Not started** | No captured green proof |
+| P0-2 | Run `GET /v1/operations/status` with admin JWT and capture callback/webhook/migration/dead-letter readiness. | Platform + API | **In progress** | PR #38 updates Janua introspection to probe `/api/v1/oauth/userinfo` (with `/api/v1/auth/me` fallback) and normalize user id/roles payloads. Awaiting deploy + prod green capture. |
 | P0-3 | Seed and verify non-empty `/v1/templates/` in production; record stable template UUIDs for smoke runs. | Platform + API | **Inconsistent** (`/v1/templates/` returns empty in public evidence run) | `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md` |
 | P0-4 | Run authenticated GPU golden path smoke (`job → callback → output → gallery`) and capture output URL trail. | API + Workers + Platform | **Not started** | Not yet captured |
 | P0-5 | Run active cancellation + multi-modal smoke under `CEQ_STRICT_SMOKE=true` with dead-letter threshold checks. | API + Workers | **Not started** | Not yet captured |
@@ -86,7 +86,7 @@ Track completion with these five high-impact lanes before broader closure.
 | Lane | Action item | Completion status |
 |------|-------------|------------------|
 | P0-1 | Get one full browser proof (`app.ceq.lol` session bootstrap + `/api/auth/session` user payload). | `Complete` (2026-06-01) |
-| P0-2 | Capture green `GET /v1/operations/status` with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`). | `Not started` |
+| P0-2 | Capture green `GET /v1/operations/status` with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`). | `In progress` |
 | P0-3 | Restore non-empty seeded `/v1/templates/` and freeze canonical template IDs for smoke. | `Inconsistent` (public evidence still empty) |
 | P0-4 | Prove authenticated GPU production golden path (`job → callback → output → gallery`) including one cancellation check. | `Not started` |
 | P1-1 | Publish/verify credits balance + entitlement proof for paying cohort; attach paid pilot receipt/invoice evidence. | `In progress` |

--- a/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
+++ b/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
@@ -13,10 +13,10 @@ CEQ can support a technical demo today and is on track for a capped GA demo once
 browser login, runtime secrets, and one authenticated GPU golden path are proven.
 That is not the same as commercial GA.
 
-**Commercial GA distance:** approximately **47%** as of this audit.
+**Commercial GA distance:** approximately **48%** as of this audit.
 
 - Technical demo and infrastructure readiness: ~100% (live evidence)
-- Capped GA readiness: ~65%
+- Capped GA readiness: ~68%
 - Full stability: ~55%
 - Limited commercial pilot: ~50%
 - Commercial GA: ~45%
@@ -35,7 +35,7 @@ Planning readiness as of 2026-06-01:
 | Milestone | Planning readiness | Basis |
 |-----------|--------------------|-------|
 | Public technical demo | Ready now | Public smoke green; landing/API live |
-| Capped GA demo | ~55-65% | Identity token route works; browser, seeded-catalog, and GPU proof remain open |
+| Capped GA demo | ~55-65% | Identity token route and browser login proof are now green; seeded-catalog and GPU proof remain open |
 | Full stability | ~50-60% | Core runtime is implemented; strict prod smoke still open |
 | Limited commercial pilot | ~50-60% | Credit/entitlement/queue/metering primitives landed; needs funded balances, GPU proof, and one supportable cohort |
 | Commercial GA | ~45-55% | Needs Dhanam billing, prod GPU proof, alert/support/legal launch pack |
@@ -51,12 +51,12 @@ the latest endpoint-attempt run is stale in
 
 | GA scope | Weight | Evidence status | Latest evidence |
 |----------|--------|----------------|----------------|
-| Capped GA demo | 30% | 46% | Browser login proof is operator-owned; operations/authenticated GPU path remains unproven in prod. |
+| Capped GA demo | 30% | 52% | Browser login proof is now captured in production; operations/authenticated GPU path remains unproven in prod. |
 | Full stability | 25% | 52% | Public smoke is green; alert/rollback drill + strict CI gate still pending. |
 | Limited commercial pilot | 25% | 40% | Credits API + billing source exist, but route has no confirmed live auth flow and entitlements are role-derived. |
 | Commercial GA | 20% | 43% | Product/legal/operations launch controls are drafted, not yet fully proven in production. |
 
-Estimated aggregate readiness remains **47%** (evidence-weighted). This is a
+Estimated aggregate readiness remains **48%** (evidence-weighted). This is a
 single-source readiness value, not a prediction of time to GA.
 
 ### GA-Critical Execution Register (as-of 2026-06-01)
@@ -65,7 +65,7 @@ Use this registry as the canonical closure board for GA-blocking work.
 
 | Priority | Action | Owner | Status | Completion signal |
 |----------|--------|-------|--------|------------------|
-| P0-1 | Capture real browser login proof on `app.ceq.lol` with authenticated session bootstrap (`/api/auth/session`, httpOnly cookies, Studio shell load). | Studio + Janua operator | **Blocked** (requires operator credentials) | Missing |
+| P0-1 | Capture real browser login proof on `app.ceq.lol` with authenticated session bootstrap (`/api/auth/session`, httpOnly cookies, Studio shell load). | Studio + Janua operator | **Complete** | `2026-06-01`: `GET /api/auth/session` returned `user`, `roles`, and `access_token` for `admin@madfam.io`; `ceq_access_token` + `ceq_refresh_token` cookies were present and `httpOnly`; Studio shell route was loaded. |
 | P0-2 | Run `GET /v1/operations/status` with admin JWT and capture callback/webhook/migration/dead-letter readiness. | Platform + API | **Not started** | No captured green proof |
 | P0-3 | Seed and verify non-empty `/v1/templates/` in production; record stable template UUIDs for smoke runs. | Platform + API | **Inconsistent** (`/v1/templates/` returns empty in public evidence run) | `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md` |
 | P0-4 | Run authenticated GPU golden path smoke (`job → callback → output → gallery`) and capture output URL trail. | API + Workers + Platform | **Not started** | Not yet captured |
@@ -85,7 +85,7 @@ Track completion with these five high-impact lanes before broader closure.
 
 | Lane | Action item | Completion status |
 |------|-------------|------------------|
-| P0-1 | Get one full browser proof (`app.ceq.lol` session bootstrap + `/api/auth/session` user payload). | `Blocked` (operator credentials still required) |
+| P0-1 | Get one full browser proof (`app.ceq.lol` session bootstrap + `/api/auth/session` user payload). | `Complete` (2026-06-01) |
 | P0-2 | Capture green `GET /v1/operations/status` with admin JWT (`callback`, `webhook`, `revision`, `dead-letter`). | `Not started` |
 | P0-3 | Restore non-empty seeded `/v1/templates/` and freeze canonical template IDs for smoke. | `Inconsistent` (public evidence still empty) |
 | P0-4 | Prove authenticated GPU production golden path (`job → callback → output → gallery`) including one cancellation check. | `Not started` |
@@ -145,7 +145,7 @@ Re-verified 2026-06-01:
 
 | Blocker | Severity | Why it matters |
 |---------|----------|----------------|
-| Real operator browser proof on `app.ceq.lol` | P0 | Commercial product acceptance cannot start without this |
+| Real operator browser proof on `app.ceq.lol` | ✅ **Cleared** | Commercial product acceptance can proceed to runtime secrets and GPU proof |
 | `GET /v1/operations/status` (admin) | P0 | Proves runtime callbacks/webhook readiness and migration state |
 | Authenticated GPU golden path in prod | P0 | Confirms core fulfillment before paid use |
 | Template catalog seeded in prod | P1 | Workflow demo paths cannot run if `/v1/templates/` is empty |
@@ -156,8 +156,8 @@ Open evidence gaps:
 
 | Gap | Blocks |
 |-----|--------|
-| Real browser login with operator credentials | Capped GA demo, any user-facing launch |
-| `operations/status` proof for callback/webhook secrets | GPU acceptance, on-call confidence |
+| `operations/status` proof for callback/webhook secrets | P0 | Runtime callback/webhook readiness remains required |
+| `operations/status` still returning `401 Invalid credentials. Signal corrupted.` for `admin@madfam.io` session token | GPU acceptance, on-call confidence |
 | Authenticated GPU golden path in prod | Demo, pilot, commercial fulfillment |
 | Template catalog remains unseeded in prod (`/v1/templates/` returns empty) | Workflow demo and premium template path availability |
 | Dhanam plan funding and entitlement source | Limited commercial pilot and commercial GA |
@@ -342,8 +342,8 @@ Dependency gates:
 ### Progress snapshot for Priority 1 (2026-06-01)
 
 - [x] Studio token route accepts Janua client secret (`invalid_grant` on bogus code)
-- [ ] Browser login + callback cookie state verified in production
-- [ ] `GET /v1/operations/status` admin proof captured
+- [x] Browser login + callback cookie state verified in production
+- [ ] `GET /v1/operations/status` admin proof captured (currently `401 Invalid credentials. Signal corrupted.`)
 - [ ] `/v1/templates/` seeded/catalog evidence captured (non-empty IDs)
 - [ ] Authenticated job + gallery output proof captured
 - [ ] `POST /v1/render/card` with Janua JWT confirms debit + cache semantics for paid path
@@ -413,6 +413,7 @@ Each run should include one row in this section and a link to raw output.
 - Date: 2026-06-01 — Endpoint matrix snapshot attempt in this session was inconsistent (DNS/connectivity); latest successful unauth matrix is `ops/evidence/2026-06-01b-prod-endpoints.csv`
 - Date: 2026-06-01 — Added reproducible unauthenticated matrix capture path:
   `scripts/capture-public-endpoint-matrix.sh` (writes to `ops/evidence/<timestamp>-public-prod-endpoints.csv` when run in a healthy network)
+- Date: 2026-06-01 — Session bootstrap evidence captured: `app.ceq.lol` login with `admin@madfam.io` returned `/api/auth/session` `user`, `roles`, `access_token`, and `ceq_access_token`/`ceq_refresh_token` `httpOnly` cookies.
 
 
 ## Implementation Tracks
@@ -574,7 +575,7 @@ Acceptance:
 
 ## Immediate Implementation Tickets
 
-1. [ ] **BLOCKED** Complete browser login proof on `app.ceq.lol` and capture authenticated session headers.
+1. [x] **DONE** Complete browser login proof on `app.ceq.lol` and capture authenticated session headers (`/api/auth/session` + httpOnly cookies).
 2. [ ] **BLOCKED** Run `operations/status` with admin JWT and require callback/webhook readiness.
 3. [ ] **BLOCKED** Seed/verify non-empty `/v1/templates/` catalog and capture a template UUID.
 4. [ ] **BLOCKED** Run one authenticated GPU golden path (`job → complete → gallery`) with output URL evidence.

--- a/docs/GA_DEMO_DEFINITION.md
+++ b/docs/GA_DEMO_DEFINITION.md
@@ -10,14 +10,14 @@
 
 CEQ is **infra-stable and partially demoable in production today**. A **capped,
 prod-quality GA demo** (real login, one golden GPU path, deterministic render
-API, InterestGate caps) is not yet declared ready because browser login proof
-and GPU golden-path proof remain open.
+API, InterestGate caps) is not yet declared ready because operations-status and
+authenticated GPU proof remain open.
 
 | Milestone | Readiness | Blocker |
 |-----------|-----------|---------|
 | Public marketing + API edge | **~90%** | None |
 | Asset pillar (`/v1/render/*`, `@ceq/sdk`) | **~90%** | Needs Janua JWT for live call |
-| Authenticated Studio (`app.ceq.lol`) | **~65%** | Janua registered; token route accepts client secret; browser proof pending |
+| Authenticated Studio (`app.ceq.lol`) | **~85%** | Janua registered; token route accepts client secret; browser proof captured |
 | End-to-end GPU job in prod | **~10%** | Janua + runtime secrets + prod smokes |
 | Capped monetization (InterestGate + API guard) | **~60%** | Interest capture, premium API guard, credit ledger, role-derived caps, feature-flagged render/GPU debits, and Studio balance readout shipped; checkout/pricing still open |
 | GA ops (strict smoke, alerts, branch protection) | **~45%** | Branch protection enabled; strict smoke and alert routing still open |
@@ -38,7 +38,7 @@ external stakeholders **without** claiming full PRD breadth. Caps are intentiona
 
 | Cap type | Mechanism | Status |
 |----------|-----------|--------|
-| **Identity** | Janua SSO; demo accounts only | Janua registered; Studio token route accepts client secret; browser proof pending |
+| **Identity** | Janua SSO; demo accounts only | Janua registered; Studio token route accepts client secret; browser proof captured |
 | **GPU throughput** | Single “golden” template + Vast.ai capacity | Not prod-proven |
 | **Templates** | 13 seeded workflow templates in repo code; production needs seed verification | Repo-seeded; prod `/v1/templates/` currently returns `{"templates":[]...}` in public check |
 | **Monetization** | InterestGate on pro/premium tags plus API-side premium guard (not checkout) | Shipped in code |
@@ -73,7 +73,7 @@ launch signoff. Track that work in
 ```
 Public / infra / render API     ████████████████████  ~90%
 CI & deploy safety              ████████████████░░░░  ~80%
-Authenticated Studio UX         █████████████░░░░░░░  ~65%
+Authenticated Studio UX         █████████████████░░░  ~85%
 End-to-end GPU in prod          ██░░░░░░░░░░░░░░░░░░  ~10%
 Capped monetization + API guard    ██████████░░░░░░  ~50%
 GA ops (alerts, strict smoke)   ██████░░░░░░░░░░░░░░  ~30%
@@ -99,6 +99,7 @@ scripts/capture-public-endpoint-matrix.sh
 | `POST /v1/render/card` (no auth) | 401 |
 | `POST app.ceq.lol/api/auth/token` with bogus code | Janua `invalid_grant` (client accepted) |
 | Janua authorize for documented client | 302 → login (registered 2026-05-23) |
+| `GET /api/auth/session` (admin credentials) | 200 with `user`, `roles`, and `access_token` payload |
 
 ### Engineering gates landed (2026-05-22 commit `b47cca8`)
 
@@ -178,8 +179,8 @@ See [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md).
 
 - [x] Janua returns no `invalid_client` for `jnc_2EJwBz8xGVsGYOO2r3ck5CJH7YrQw4Yk` (302 authorize, 2026-05-23)
 - [x] Studio token route accepts mounted Janua client secret (`invalid_grant` for bogus code, 2026-06-01)
-- [ ] Browser login on `app.ceq.lol` completes OAuth callback with real credentials
-- [ ] `GET /api/auth/session` returns `user` + `access_token` with session cookies
+- [x] Browser login on `app.ceq.lol` completes OAuth callback with real credentials
+- [x] `GET /api/auth/session` returns `user` + `access_token` with session cookies
 - [ ] Logout clears CEQ cookies and completes Janua post-logout redirect
 - [x] Studio `env`: `JANUA_CLIENT_SECRET` mounted at runtime (inferred from token route)
 


### PR DESCRIPTION
Fix CEQ API token validation to probe /api/v1/oauth/userinfo (current Janua contract) before legacy /api/v1/auth/me, and normalize id/sub and role fields from both responses. This should resolve authenticated production /v1/operations/status calls with Studio-issued tokens.