### PR TITLE
fix(ci): restore CEQ deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -266,9 +266,6 @@ jobs:
       # since acecfd5 (75s × 5 retries, then exit 1).
       digest: ${{ steps.build.outputs.digest }}
 
-    outputs:
-      digest: ${{ steps.digest.outputs.digest }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove duplicate stale build-worker outputs block from CEQ Deploy workflow
- restore worker digest output from docker/build-push-action so workflow can parse and run

## Verification
- ruby YAML parse for .github/workflows/deploy.yaml
- PYTHONPATH=src python -m pytest tests/test_operations.py tests/test_credits.py