### PR TITLE
chore(studio): align landing metadata and auth copy

### DIFF
--- a/apps/studio/e2e/auth.spec.ts
+++ b/apps/studio/e2e/auth.spec.ts
@@ -16,7 +16,7 @@ test.describe("Studio auth (mocked Janua)", () => {
   }) => {
     await page.goto("/workflows");
     await expect(page).toHaveURL(/\/login\?returnTo=%2Fworkflows/);
-    await expect(page.getByRole("button", { name: "Enter the Terminal" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enter CEQ Studio" })).toBeVisible();
   });
 
   test("completes mocked OAuth callback and renders the studio shell", async ({
@@ -25,7 +25,7 @@ test.describe("Studio auth (mocked Janua)", () => {
     await installAuthenticatedShellMocks(page);
 
     await page.goto("/login?returnTo=%2F");
-    await page.getByRole("button", { name: "Enter the Terminal" }).click();
+    await page.getByRole("button", { name: "Enter CEQ Studio" }).click();
 
     await expect(page).toHaveURL(/\/auth\/callback/, { timeout: 10_000 });
     await expect(page).toHaveURL(/http:\/\/127\.0\.0\.1:5801\/(\?|$)/, {
@@ -58,7 +58,7 @@ test.describe("Studio auth (mocked Janua)", () => {
     await installAuthenticatedShellMocks(page);
 
     await page.goto("/login?returnTo=%2F");
-    await page.getByRole("button", { name: "Enter the Terminal" }).click();
+    await page.getByRole("button", { name: "Enter CEQ Studio" }).click();
     await expect(page.getByRole("heading", { name: "Workflows" })).toBeVisible({
       timeout: 15_000,
     });

--- a/apps/studio/src/app/layout.tsx
+++ b/apps/studio/src/app/layout.tsx
@@ -15,23 +15,26 @@ const fontSans = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "ceq | Creative Entropy Quantized",
-  description: "Generative AI image pipeline by MADFAM. The skunkworks terminal for the generative avant-garde.",
+  title: "ceq | Production Control Plane for Generative Media",
+  description:
+    "CEQ turns repeatable ComfyUI workflows into deterministic render APIs, galleries, billing-ready credits, and client-safe generative production.",
   metadataBase: new URL("https://ceq.lol"),
   icons: {
     icon: "/favicon.ico",
   },
   openGraph: {
-    title: "CEQ Studio — Generative AI Image Pipeline",
-    description: "The skunkworks terminal for the generative avant-garde. Wraps ComfyUI with a streamlined, hacker-centric interface.",
+    title: "CEQ Studio — Production Control Plane for Generative Media",
+    description:
+      "Run reusable templates, preserve seeds, control GPU cost, cache outputs, and ship client-ready image, audio, and 3D assets.",
     url: "https://ceq.lol",
     siteName: "CEQ Studio by MADFAM",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "CEQ Studio — Generative AI Image Pipeline",
-    description: "The skunkworks terminal for the generative avant-garde.",
+    title: "CEQ Studio — Production Control Plane for Generative Media",
+    description:
+      "Reusable ComfyUI workflows, deterministic render APIs, cached outputs, and client-safe generative production.",
   },
 };
 

--- a/apps/studio/src/app/login/page.tsx
+++ b/apps/studio/src/app/login/page.tsx
@@ -44,15 +44,16 @@ export default function LoginPage() {
 
         {/* Hero section */}
         <h1 className="mt-6 text-xl font-semibold text-foreground text-center">
-          CEQ Studio — Generative AI Image Pipeline
+          CEQ Studio — Generative Production Control Plane
         </h1>
 
         {/* Tagline */}
         <p className="mt-2 text-sm text-muted-foreground text-center max-w-sm">
-          Creative Entropy Quantized
+          Reusable ComfyUI workflows, deterministic render APIs,
+          cached outputs, and client-safe galleries.
           <br />
           <span className="text-xs opacity-75">
-            The skunkworks terminal for the generative avant-garde
+            Sign in to run the Studio, queue jobs, and preserve every proof.
           </span>
         </p>
 
@@ -67,7 +68,7 @@ export default function LoginPage() {
           onClick={() => login(returnTo)}
           className="mt-8 px-6 py-2 text-sm border border-border rounded hover:bg-accent transition-colors"
         >
-          Enter the Terminal
+          Enter CEQ Studio
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- updates global metadata, Open Graph, and Twitter copy to match the new production-control-plane landing narrative
- aligns the login/auth gate CTA and supporting copy with the redesigned CEQ positioning
- updates mocked-auth Playwright selectors for the new CTA label

## Verification
- pnpm --filter @ceq/studio typecheck
- pnpm --filter @ceq/studio lint
- pnpm --filter @ceq/studio test -- --run __tests__/components/marketing-landing.test.tsx
- pnpm test:e2e (rerun escalated locally after sandbox blocked binding 127.0.0.1:5999)