### PR TITLE
feat(api): entitlement claims for paid gating

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -270,14 +270,17 @@ Role claim handling is intentionally defensive:
 - Single string roles (for example `"Admin"`) and iterable role claims are
   normalized into a list.
 - Role normalization lowercases values and converts underscores to hyphens (for
-  example `"Studio_Admin"` → `"studio-admin"`) before entitlement checks.
+- example `"Studio_Admin"` → `"studio-admin"`) before entitlement checks.
+- Entitlement claims are also supported. `entitlements`, `plan`, `plan_id`,
+  `subscription`, and `subscription_tier` (including list-style variants) map
+  into paid access during entitlement evaluation.
 
 ## Monetization gating (InterestGate)
 
 CEQ is still pre-checkout, but premium template execution now has an API-side
-guard. Templates tagged `pro` or `premium` require a paid/admin Janua role for
-direct template `fork`/`run`, synthesis-selected premium templates, and
-premium-origin workflow runs.
+guard. Templates tagged `pro` or `premium` require a paid/admin Janua role or a
+supported entitlement claim for direct template `fork`/`run`, synthesis-selected
+premium templates, and premium-origin workflow runs.
 
 The studio still uses the **InterestGate** pattern for demand capture: gated UI
 is wrapped in `<InterestGate featureKey="..." variant="overlay">` (see

--- a/apps/api/src/ceq_api/auth/janua.py
+++ b/apps/api/src/ceq_api/auth/janua.py
@@ -187,6 +187,7 @@ class JanuaUser:
     email: str
     org_id: UUID | None = None
     roles: list[str] | None = None
+    entitlements: list[str] | None = None
 
     @property
     def is_admin(self) -> bool:
@@ -212,6 +213,36 @@ def _normalize_roles(value: Any) -> list[str] | None:
         if isinstance(role, (str, UUID, int, float)) and not isinstance(role, dict)
     ]
     return roles if roles else None
+
+
+def _normalize_entitlements(value: Any) -> list[str] | None:
+    """Normalize entitlement claims from token payloads into a list of strings."""
+    if value is None:
+        return None
+
+    values = value
+
+    if isinstance(value, dict):
+        nested = value.get("id") or value.get("slug") or value.get("name")
+        if nested is None:
+            return None
+        values = nested
+
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, dict)):
+        values = list(value)
+    else:
+        values = [value]
+
+    entitlements = [
+        str(entitlement).strip().lower().replace("_", "-")
+        for entitlement in values
+        if isinstance(entitlement, (str, UUID, int, float))
+        and not isinstance(entitlement, dict)
+        and str(entitlement).strip()
+    ]
+    return entitlements if entitlements else None
 
 
 # ---------------------------------------------------------------------------
@@ -260,11 +291,24 @@ async def _validate_token_introspection(token: str) -> JanuaUser | None:
         if roles_raw is None:
             roles_raw = data.get("role")
 
+        entitlements = _normalize_entitlements(
+            data.get("entitlements")
+            or data.get("plan")
+            or data.get("plan_id")
+            or data.get("subscription")
+            or data.get("subscription_tier")
+        )
+        if entitlements is None:
+            plans = data.get("plans")
+            if isinstance(plans, list):
+                entitlements = _normalize_entitlements(plans)
+
         user = JanuaUser(
             id=UUID(user_id),
             email=email,
             org_id=UUID(data["org_id"]) if data.get("org_id") else None,
             roles=_normalize_roles(roles_raw),
+            entitlements=entitlements,
         )
         logger.debug("Token validated via introspection for user %s", user.email)
         return user
@@ -334,12 +378,24 @@ def _validate_token_local(token: str) -> JanuaUser | None:
         logger.warning("JWT missing required claims (sub, email)")
         return None
 
+    entitlements = _normalize_entitlements(
+        payload.get("entitlements")
+        or payload.get("plan")
+        or payload.get("plan_id")
+        or payload.get("subscription")
+        or payload.get("subscription_tier")
+    )
+    if entitlements is None:
+        plans = payload.get("plans")
+        if isinstance(plans, list):
+            entitlements = _normalize_entitlements(plans)
+
     user = JanuaUser(
         id=UUID(sub),
         email=email,
         org_id=UUID(payload["org_id"]) if payload.get("org_id") else None,
-        roles=_normalize_roles(payload.get("roles"))
-        or _normalize_roles(payload.get("role")),
+        roles=_normalize_roles(payload.get("roles")) or _normalize_roles(payload.get("role")),
+        entitlements=entitlements,
     )
     logger.debug(f"Token validated locally (JWKS) for user {user.email}")
     return user

--- a/apps/api/src/ceq_api/entitlements.py
+++ b/apps/api/src/ceq_api/entitlements.py
@@ -14,33 +14,48 @@ from ceq_api.auth import JanuaUser
 from ceq_api.models import Template
 
 PREMIUM_TEMPLATE_TAGS = {"pro", "premium"}
-PAID_TEMPLATE_ROLES = {
-    "admin",
+PAID_TEMPLATE_ROLES = {"admin", "paid", "pro", "premium", "studio"}
+PAID_TEMPLATE_ENTITLEMENTS = PAID_TEMPLATE_ROLES | {
     "ceq-admin",
     "ceq:admin",
-    "paid",
-    "pro",
-    "premium",
-    "studio",
+    "ceq-paid",
     "ceq-pro",
     "ceq-premium",
     "ceq-studio",
     "ceq:pro",
     "ceq:premium",
     "ceq:studio",
-    "plan-pro",
-    "plan-premium",
-    "plan-studio",
+    "plan:paid",
     "plan:pro",
     "plan:premium",
     "plan:studio",
-    "tier-pro",
-    "tier-premium",
-    "tier-studio",
+    "plan-paid",
+    "plan-pro",
+    "plan-premium",
+    "plan-studio",
+    "tier:paid",
     "tier:pro",
-    "tier:premium",
-    "tier:studio",
+    "tier-pro",
+    "tier-paid",
 }
+
+
+def _expand_entitlement_values(values: Iterable[object] | None) -> set[str]:
+    normalized = _normalize(values)
+    expanded = set(normalized)
+
+    for value in normalized:
+        if value.startswith("ceq-") or value.startswith("ceq:"):
+            expanded.add(value.removeprefix("ceq:").removeprefix("ceq-"))
+        if value.startswith("plan:") or value.startswith("plan-"):
+            expanded.add(value.split(":", 1)[1] if ":" in value else value.split("-", 1)[1])
+        if value.startswith("tier:") or value.startswith("tier-"):
+            expanded.add(value.split(":", 1)[1] if ":" in value else value.split("-", 1)[1])
+
+        if value.endswith("-artist"):
+            expanded.add(value.removesuffix("-artist"))
+
+    return expanded
 
 
 def _normalize(values: Iterable[object] | None) -> set[str]:
@@ -59,7 +74,10 @@ def template_requires_paid_entitlement(template: Template) -> bool:
 
 def user_can_use_paid_templates(user: JanuaUser) -> bool:
     """Return true when Janua roles grant paid-template access."""
-    return user.is_admin or bool(_normalize(user.roles) & PAID_TEMPLATE_ROLES)
+    capability_tokens = _expand_entitlement_values(
+        _normalize(user.roles) | _normalize(getattr(user, "entitlements", None))
+    )
+    return user.is_admin or bool(capability_tokens & PAID_TEMPLATE_ENTITLEMENTS)
 
 
 def require_template_entitlement(template: Template, user: JanuaUser) -> None:

--- a/apps/api/src/ceq_api/quotas.py
+++ b/apps/api/src/ceq_api/quotas.py
@@ -16,28 +16,52 @@ PRO_QUOTA_ROLES = {
     "paid",
     "pro",
     "premium",
-    "ceq-pro",
-    "ceq-premium",
-    "ceq:pro",
-    "ceq:premium",
-    "plan-pro",
-    "plan-premium",
+    "plan:paid",
     "plan:pro",
     "plan:premium",
-    "tier-pro",
-    "tier-premium",
+    "plan-paid",
+    "plan-pro",
+    "plan-premium",
+    "tier:paid",
     "tier:pro",
     "tier:premium",
+    "tier-paid",
+    "tier-pro",
+    "tier-premium",
+    "ceq-paid",
+    "ceq-pro",
+    "ceq-premium",
+    "ceq:paid",
+    "ceq:pro",
+    "ceq:premium",
 }
 STUDIO_QUOTA_ROLES = {
     "studio",
+    "plan:studio",
+    "plan-studio",
+    "tier:studio",
+    "tier-studio",
     "ceq-studio",
     "ceq:studio",
-    "plan-studio",
-    "plan:studio",
-    "tier-studio",
-    "tier:studio",
 }
+
+
+def _expand_quota_tokens(values: Iterable[object] | None) -> set[str]:
+    normalized = _normalize(values)
+    expanded = set(normalized)
+
+    for value in normalized:
+        if value.startswith("ceq-") or value.startswith("ceq:"):
+            expanded.add(value.removeprefix("ceq:").removeprefix("ceq-"))
+        if value.startswith("plan:") or value.startswith("plan-"):
+            expanded.add(value.split(":", 1)[1] if ":" in value else value.split("-", 1)[1])
+        if value.startswith("tier:") or value.startswith("tier-"):
+            expanded.add(value.split(":", 1)[1] if ":" in value else value.split("-", 1)[1])
+
+        if value.endswith("-artist"):
+            expanded.add(value.removesuffix("-artist"))
+
+    return expanded
 
 
 def _normalize(values: Iterable[object] | None) -> set[str]:
@@ -51,11 +75,15 @@ def _normalize(values: Iterable[object] | None) -> set[str]:
 def active_job_limit_for_user(user: JanuaUser, settings: Any) -> int:
     """Resolve the active-job cap for the user's current plan/role."""
     roles = _normalize(user.roles)
+    entitlements = _normalize(getattr(user, "entitlements", None))
+
+    caps = roles | entitlements
+    expanded_caps = _expand_quota_tokens(caps)
     if user.is_admin:
         return int(settings.max_active_jobs_admin)
-    if roles & STUDIO_QUOTA_ROLES:
+    if expanded_caps & STUDIO_QUOTA_ROLES:
         return int(settings.max_active_jobs_studio)
-    if roles & PRO_QUOTA_ROLES:
+    if expanded_caps & PRO_QUOTA_ROLES:
         return int(settings.max_active_jobs_pro)
     return int(settings.max_active_jobs_per_user)
 

--- a/apps/api/tests/test_entitlements.py
+++ b/apps/api/tests/test_entitlements.py
@@ -1,0 +1,105 @@
+"""Commercial entitlement tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from ceq_api.auth import JanuaUser
+from ceq_api.entitlements import (
+    PAID_TEMPLATE_ENTITLEMENTS,
+    PREMIUM_TEMPLATE_TAGS,
+    require_template_entitlement,
+    user_can_use_paid_templates,
+)
+from ceq_api.models import Template
+from ceq_api.quotas import active_job_limit_for_user
+
+
+def test_paid_template_entitlement_via_roles() -> None:
+    """Role tokens continue to grant paid-template access."""
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="pro@example.com",
+        roles=["free", "Pro"],
+    )
+    assert user_can_use_paid_templates(user)
+
+
+def test_paid_template_entitlement_via_plan_claim() -> None:
+    """Plan claim tokens should grant paid-template access."""
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="plan@example.com",
+        entitlements=["plan:pro"],
+    )
+    assert user_can_use_paid_templates(user)
+
+
+def test_paid_template_entitlement_via_plan_alias() -> None:
+    """Alias-style entitlement claims should map to quota/template tokens."""
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="planalias@example.com",
+        entitlements=["pro-artist"],
+    )
+    assert user_can_use_paid_templates(user)
+
+
+def test_premium_template_entitlement_gate() -> None:
+    """Un-entitled users cannot run premium templates."""
+    template = Template(
+        name="Premium Surface",
+        category="utility",
+        workflow_json={},
+        input_schema={},
+        tags=["premium"],
+    )
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="free@example.com",
+        roles=["creator"],
+    )
+
+    with pytest.raises(HTTPException):
+        require_template_entitlement(template, user)
+
+
+def test_active_job_quota_uses_plan_entitlements() -> None:
+    """Plan-style entitlements should map into quota classes."""
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="plan-user@example.com",
+        entitlements=["plan_studio"],
+    )
+    settings = SimpleNamespace(
+        max_active_jobs_admin=30,
+        max_active_jobs_studio=12,
+        max_active_jobs_pro=7,
+        max_active_jobs_per_user=4,
+    )
+    assert active_job_limit_for_user(user, settings) == 12
+
+
+def test_template_entitlement_metadata_includes_normalized_tokens() -> None:
+    """Metadata returns normalized template tags and entitlement details."""
+    template = Template(
+        name="Premium Template",
+        category="social",
+        workflow_json={},
+        input_schema={},
+        tags=["  PRo", "Premium", "creative"],
+    )
+    user = JanuaUser(
+        id="00000000-0000-0000-0000-000000000001",
+        email="basic@example.com",
+        roles=["guest"],
+        entitlements=["ceq:premium"],
+    )
+
+    require_template_entitlement(template, user)
+
+    assert "premium" in PREMIUM_TEMPLATE_TAGS
+    assert "ceq:premium" in PAID_TEMPLATE_ENTITLEMENTS

--- a/docs/API.md
+++ b/docs/API.md
@@ -505,8 +505,9 @@ POST /v1/templates/{id}/run
 
 Runs a template directly and returns a queued job.
 
-Templates tagged `pro` or `premium` require a paid/admin Janua role before
-`fork` or `run`. The same entitlement check is applied when running a workflow
+Templates tagged `pro` or `premium` require a paid/admin Janua role or a paid
+entitlement claim for `fork` or `run`. The same entitlement check is applied
+when running a workflow
 derived from a premium template, so direct API callers cannot bypass the Studio
 InterestGate by forking first.
 

--- a/docs/CEQ_STABILITY_ROADMAP.md
+++ b/docs/CEQ_STABILITY_ROADMAP.md
@@ -177,7 +177,7 @@ and `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`.
 | P0-4 | Platform | Template catalog seeded (`/v1/templates/` returns non-empty IDs) | Inconsistent | Public evidence currently empty |
 | P0-5 | Stability | Cancel + multi-modal + strict smoke pass in production | Not started | Not yet captured |
 | P1-1 | Monetization | Dhanam-backed plan/checkout and funded entitlements live | Not started | Not yet captured |
-| P1-2 | Monetization | Entitlements are enforced server-side (not UI-only) | In progress | Role-derived guards landed |
+| P1-2 | Monetization | Entitlements are enforced server-side (not UI-only) | In progress | Role/entitlement-claim guards landed |
 | P1-3 | Reliability | Alerts and rollback drills hit on-call/owner paths | Not started | Not yet proven |
 | P1-4 | Legal/commercial | Terms, privacy, pricing, and support docs are linked in user flows | In progress | Public landing and `/billing` link legal/commercial routes; legal approval still pending |
 | P1-5 | Launch | Paid pilot + launch signoff with incident/runbook rehearsals | Not started | Not yet executed |
@@ -275,7 +275,7 @@ Commercial GA gates:
 | Billing | Dhanam checkout/invoice path or approved pilot billing bridge works |
 | Credits | Initial ledger/API, Studio account balance, and feature-flagged render/GPU debit-refund plumbing landed; billing reconciliation still required |
 | Entitlements | Initial premium/pro API guard landed; Dhanam-backed plan source still required |
-| Quotas/abuse | Role-derived active-job caps landed; Dhanam-backed queue/rate/spend limits still required |
+| Quotas/abuse | Role/entitlement-aware active-job caps landed; Dhanam-backed queue/rate/spend limits still required |
 | Observability/support | Alerts route to on-call; support macros and escalation runbooks exist |
 | Security/legal | AuthZ, audit logs, terms, privacy, acceptable-use, and retention docs are ready |
 | Launch signoff | Product, engineering, platform, and support sign off with evidence links |
@@ -733,7 +733,7 @@ gates pass.
 |------|-------|-------|
 | Template catalog expansion | Product + eng | 6 checked-in workflow JSON files + 13 seeded DB templates; PRD lists dozens — prioritize social + video MVP |
 | Publishing channels | `apps/api` outputs | Twitter/Instagram/LinkedIn/Discord `coming_soon`; webhook only live |
-| Monetization | Product + Dhanam + API + Studio | InterestGate exists; initial API-side premium guard, credit ledger, role-derived active-job caps, Studio account balance, and feature-flagged render/GPU debits landed 2026-06-01; commercial GA still requires Dhanam checkout, billing reconciliation, Dhanam-backed quotas, and full Studio billing UX per [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md) |
+| Monetization | Product + Dhanam + API + Studio | InterestGate exists; initial API-side premium guard, credit ledger, role/entitlement-aware active-job caps, Studio account balance, and feature-flagged render/GPU debits landed 2026-06-01; commercial GA still requires Dhanam checkout, billing reconciliation, Dhanam-backed quotas, and full Studio billing UX per [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md) |
 | Landing conversion | Studio landing | Outcome-first landing with product proof panel, simulated deterministic render/cache-hit demo, founding-pilot CTAs, and lightweight event hooks; connect analytics sink after deploy |
 | Furnace migration | Workers | Vast.ai today; Furnace provider not deployed |
 | PRD promotion | Product | Move from Draft v0.1.0 to accepted MVP spec |
@@ -828,8 +828,8 @@ app gate on `app.ceq.lol`.
 5. [ ] **BLOCKED** **CEQ operator:** Run authenticated GPU + cancel + multi-modal smokes
 6. [ ] **IN PROGRESS** **Product + engineering:** Freeze commercial launch SKU, credit units, and
    supported template catalog
-7. [ ] **IN PROGRESS** **API + Dhanam:** Replace initial role-based entitlement checks and
-   role-derived quotas with Dhanam plan state; fund balances and enable
+7. [ ] **IN PROGRESS** **API + Dhanam:** Replace initial role/entitlement checks and
+   role/entitlement-claim quotas with Dhanam plan state; fund balances and enable
    render/GPU debit flags for a pilot cohort
 
 ---

--- a/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
+++ b/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
@@ -54,7 +54,7 @@ Earlier successful reruns remain as `ops/evidence/2026-06-01T2200-public-prod-en
 |----------|--------|----------------|----------------|
 | Capped GA demo | 30% | 52% | Browser login proof is now captured in production; operations/authenticated GPU path remains unproven in prod. |
 | Full stability | 25% | 52% | Public smoke is green; alert/rollback drill + strict CI gate still pending. |
-| Limited commercial pilot | 25% | 40% | Credits API + billing source exist, but route has no confirmed live auth flow and entitlements are role-derived. |
+| Limited commercial pilot | 25% | 40% | Credits API + billing source exist, but route has no confirmed live auth flow and entitlements are role/entitlement-claim aware. |
 | Commercial GA | 20% | 43% | Product/legal/operations launch controls are drafted, not yet fully proven in production. |
 
 Estimated aggregate readiness remains **48%** (evidence-weighted). This is a
@@ -72,9 +72,9 @@ Use this registry as the canonical closure board for GA-blocking work.
 | P0-4 | Run authenticated GPU golden path smoke (`job → callback → output → gallery`) and capture output URL trail. | API + Workers + Platform | **Not started** | Not yet captured |
 | P0-5 | Run active cancellation + multi-modal smoke under `CEQ_STRICT_SMOKE=true` with dead-letter threshold checks. | API + Workers | **Not started** | Not yet captured |
 | P1-1 | Finalize Dhanam-backed plan/checkout path for paid signup and plan changes. | Product + Dhanam + API | **In progress** | Studio checkout bridge now targets Dhanam catalog product `ceq`; enablement still requires entitlement source proof |
-| P1-2 | Replace role-derived paid API gates with entitlement checks backed by plan state and server-side grants. | API | **In progress** (role-based guards landed) | No plan-backed enforcement evidence yet |
+| P1-2 | Replace role-only paid API gates with entitlement checks backed by plan state and server-side grants. | API | **In progress** (role/entitlement claim guards landed) | No plan-backed enforcement evidence yet |
 | P1-3 | Enable and reconcile feature-flagged render/GPU debit-refund flow for a pilot cohort. | API | **In progress** (code paths exist, flags available) | Not yet bound to funded flow |
-| P1-4 | Replace role-derived caps with plan/rate/spend quotas tied to production entitlements. | API + Platform | **In progress** (schema + quotas exist, billing source missing) | No paid traffic evidence |
+| P1-4 | Replace role-only caps with plan/rate/spend quotas tied to production entitlements. | API + Platform | **In progress** (schema + quotas exist, billing source missing) | No paid traffic evidence |
 | P1-5 | Confirm alert + rollback drill evidence, link synthetic alert path, and attach runbooks to alert annotations. | Platform + Support | **Not started** | Not yet linked |
 | P1-6 | Publish and link customer-facing legal/commercial docs (terms, privacy, AUP, pricing, limits) from GA flows. | Product + Legal | **In progress** | Studio `/billing` and the redesigned landing link `/legal/{terms,privacy,acceptable-use,retention,refunds}`; legal review still required |
 | P1-7 | Publish fresh-account paid pilot rehearsal evidence (login, generation, invoice/receipt, output retrieval). | Product + Eng + Support | **Not started** | Not yet executed |
@@ -173,7 +173,7 @@ Code progress since this baseline:
 | 2026-06-01 | Per-user active job cap added for workflow/template/synthesis submissions via `MAX_ACTIVE_JOBS_PER_USER` | Replace the global cap with plan-aware Dhanam quotas and Studio limit UI |
 | 2026-06-01 | Studio credit balance UI is wired to `/v1/credits/balance` | Confirm endpoint is live in production and add usage history, upgrade, exhausted-credit, and payment-failure states |
 | 2026-06-01 | Render cache-miss debit plumbing added behind `RENDER_CREDIT_DEBITS_ENABLED` | Fund balances from Dhanam/pilot grants, enable for pilot cohort, and add GPU job debit/refund metering |
-| 2026-06-01 | Plan-aware active-job caps added for free/pro/studio/admin roles | Replace role-derived limits with Dhanam plan state when billing source is live |
+| 2026-06-01 | Plan-aware active-job caps added for free/pro/studio/admin roles | Replace role-only limits with Dhanam plan state when billing source is live |
 | 2026-06-01 | GPU job debit/refund plumbing added behind `GPU_JOB_CREDIT_DEBITS_ENABLED` | Fund balances, enable for pilot cohort, and reconcile ledger to completed jobs/billing export |
 | 2026-06-01 | GitHub `main` branch protection enabled with required CEQ CI checks and review gate | Keep required checks current as workflow names change |
 | 2026-06-01 | Studio billing page added with Dhanam checkout URL bridge for catalog product `ceq` tiers `pro_artist` and `studio`, gated by `NEXT_PUBLIC_CEQ_CHECKOUT_ENABLED` | Keep checkout disabled until Dhanam entitlement source and paid-run proof are captured |
@@ -363,7 +363,7 @@ Dependency gates:
 - [x] Credit ledger schema and `/v1/credits/*` APIs exist in code
 - [ ] `/v1/credits/balance` route is 401/403 for unauthenticated users and works with valid user token (currently `404` unauthenticated)
 - [ ] Credit balance surfacing in Studio depends on production `credits` endpoint availability
-- [x] Role-derived premium gating and per-user active-job caps landed
+- [x] Role/entitlement-claim premium gating and per-user active-job caps landed
 - [x] Dhanam checkout bridge exists in Studio, feature-flagged off by default until entitlement proof
 - [ ] No Dhanam-backed entitlement source wired into API enforcement
 
@@ -376,7 +376,7 @@ Dependency gates:
 
 ### Priority 3 — Reliability, support, and compliance
 
-7. Replace role-derived caps with plan-aware quota/rate/spend controls.
+7. Replace role-only caps with plan-aware quota/rate/spend controls.
 8. Add/lock alert routing, runbooks, and rollback drill evidence.
 9. Publish support macros and customer-facing terms/privacy/AUP/retention.
 
@@ -490,15 +490,15 @@ Tasks:
 - Extend the initial credit ledger tables/API into Dhanam-backed plan funding
 - Meter every billable generation and render action server-side; render cache-miss and GPU job debit/refund plumbing landed behind feature flags
 - Make credit deduction idempotent against retries and callbacks
-- Replace initial role-based premium template API enforcement with Dhanam-backed entitlements
-- Replace role-derived plan caps with Dhanam-backed queue/rate/spend quotas
+- Replace initial role/entitlement-claim premium template API enforcement with Dhanam-backed entitlements
+- Replace role/entitlement-aware plan caps with Dhanam-backed queue/rate/spend quotas
 - Add usage summary and remaining credit views in Studio; account-menu balance landed 2026-06-01
 - Add admin credit grant/adjustment workflow with audit trail
 
 Acceptance:
 
-- Free users cannot invoke premium templates by direct API call (initial role-based guard landed 2026-06-01)
-- Paid users cannot exceed plan credits/queue limits without explicit overage policy (role-derived active-job caps landed 2026-06-01)
+- Free users cannot invoke premium templates by direct API call (initial role/entitlement-claim guard landed 2026-06-01)
+- Paid users cannot exceed plan credits/queue limits without explicit overage policy (role/entitlement-aware active-job caps landed 2026-06-01)
 - Each completed paid job has exactly one ledger entry tied to job/output IDs
 - Failed/cancelled jobs have clear refund/no-charge semantics
 
@@ -588,7 +588,7 @@ Acceptance:
 4. [ ] **BLOCKED** Run one authenticated GPU golden path (`job → complete → gallery`) with output URL evidence.
 5. [ ] **IN PROGRESS** Add `/v1/credits/balance` and credit-route auth behavior into `CEQ_PUBLIC_ONLY=true` + authenticated smoke evidence.
 6. [ ] **NOT STARTED** Enable credit plan source (Dhanam bridge or approved pilot billing bridge) and verify one paid action with debits.
-7. [ ] **IN PROGRESS** Replace role-derived paid-template/API enforcement with entitlement-backed checks.
+7. [ ] **IN PROGRESS** Replace role-only paid-template/API enforcement with entitlement-backed checks.
 8. [ ] **IN PROGRESS** Finalize queue/rate/spend guardrails in API + worker path.
 9. [ ] **NOT STARTED** Confirm alert routing + rollback drill evidence and link runbooks.
 10. [ ] **IN PROGRESS** Publish customer-facing legal/commercial docs (terms/privacy/AUP/retention/recovery) in public landing and Studio paths.

--- a/docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md
+++ b/docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md
@@ -67,7 +67,7 @@ credentials.
 | Deployment docs | Replaced stale `ceq-prod` tunnel guidance with platform `enclii-prod` tunnel status. |
 | Legacy deploy script | Disabled legacy `ceq-prod` tunnel creation unless `CEQ_ALLOW_LEGACY_TUNNEL=true` is explicitly set. |
 | Digest docs | Updated current kustomization digest table in the stability roadmap. |
-| Commercial controls | Added credit ledger, role-derived entitlement/quota guards, feature-flagged render/GPU debits, and Studio balance readout to docs. |
+| Commercial controls | Added credit ledger, role/entitlement-claim entitlement and quota guards, feature-flagged render/GPU debits, and Studio balance readout to docs. |
 | Branch protection | Enabled `main` protection and removed it from open GA blockers. |
 
 ## Remaining Unverified Claims

--- a/docs/GA_DEMO_DEFINITION.md
+++ b/docs/GA_DEMO_DEFINITION.md
@@ -19,7 +19,7 @@ authenticated GPU proof remain open.
 | Asset pillar (`/v1/render/*`, `@ceq/sdk`) | **~90%** | Needs Janua JWT for live call |
 | Authenticated Studio (`app.ceq.lol`) | **~85%** | Janua registered; token route accepts client secret; browser proof captured |
 | End-to-end GPU job in prod | **~10%** | Janua + runtime secrets + prod smokes |
-| Capped monetization (InterestGate + API guard) | **~60%** | Interest capture, premium API guard, credit ledger, role-derived caps, feature-flagged render/GPU debits, and Studio balance readout shipped; checkout/pricing still open |
+| Capped monetization (InterestGate + API guard) | **~60%** | Interest capture, premium API guard, claim-aware caps, feature-flagged render/GPU debits, and Studio balance readout shipped; checkout/pricing still open |
 | GA ops (strict smoke, alerts, branch protection) | **~45%** | Branch protection enabled; strict smoke and alert routing still open |
 
 **Critical path:** ~~Janua OAuth registration~~ done (2026-05-23) →
@@ -60,7 +60,7 @@ multi-channel publishing, paid checkout, or full observability on-call proof.
 
 Commercial GA is a separate milestone. A capped GA demo proves that CEQ can be
 shown on production infrastructure with tight scope; it does **not** prove that
-CEQ can be sold broadly. Paid launch requires server-side credits, API
+CEQ can be sold broadly. Paid launch requires server-side credits, plan-backed
 entitlements, billing/checkout, quotas, support, legal/commercial docs, and
 launch signoff. Track that work in
 [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md) and


### PR DESCRIPTION
Adds entitlement claim ingestion to Janua auth and entitlement/quotas checks, plus API tests and documentation updates for commercial GA truthfulness.\n\nIncludes support for entitlement claims (entitlements, plan, plan_id, subscription, subscription_tier, plans), claim expansion for premium checks, and plan-aware caps.