### PR TITLE
docs: reconcile CEQ truth layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,15 @@ redirect and should not become the source of truth again.
 - `docs/`
 - `.github/workflows/`
 
+## Current documentation truth
+
+- `docs/README.md` is the documentation map and precedence guide.
+- `docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md` is the current audit wrap-up.
+- `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md` is the current evidence-backed
+  production snapshot.
+- Older imported or session-specific sections below are historical context when
+  they conflict with the latest evidence audit.
+
 ## LLM context files
 
 - `llms.txt` is the compact context index.

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -23,7 +23,7 @@ CEQ is MADFAM's internal content generation platform: a streamlined hacker-centr
 
 **Pillar**: Brand / Asset pillar
 **Type**: service
-**Status**: production (public edge stable; capped GA still pending browser login proof and GPU E2E — `docs/GA_DEMO_DEFINITION.md`; commercial GA still pending billing/credits/entitlements/quotas/support launch work — `docs/COMMERCIAL_GA_REMEDIATION_PLAN.md`; Janua OAuth registered 2026-05-23; Studio token route accepted client secret in the 2026-06-01 audit — `docs/JANUA_OPERATOR.md`)
+**Status**: production public edge stable, not commercial GA. Current truth is in `docs/README.md`, `docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`, and `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`: public smoke is green; `ceq-api` and `ceq-studio` are healthy in Enclii; `ceq-janua-client-secret` ExternalSecret is degraded until Vault `secret/ceq.JANUA_CLIENT_SECRET` is populated; authenticated smoke and GPU E2E remain unproven; commercial GA still needs billing, credits, entitlements, quotas, support, and observability launch work.
 
 ### Deployed services
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,21 @@
 **ceq** wraps the raw power of [ComfyUI](https://github.com/comfyanonymous/ComfyUI) with a streamlined, hacker-centric interface. Full node power when you need it, a clean UX when you don't.
 
 **Domain:** [ceq.lol](https://ceq.lol)
-**Status:** Live — public landing, authenticated Studio route, and API deployed; `/v1/render` pipeline shipped 2026-04-19
+**Status:** Live public surfaces; not commercial GA. Public smoke is green, but authenticated smoke, ExternalSecret health, GPU golden-path proof, and paid-launch controls remain open.
 **Philosophy:** *Wrestling order from the chaos of latent space*
+
+---
+
+## Current documentation truth
+
+Start with [`docs/README.md`](./docs/README.md), then the latest audit wrap-up
+and evidence:
+
+- [`docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md)
+- [`docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md)
+
+Older roadmap, deployment, and handoff docs preserve historical context. When
+they conflict, the latest evidence audit wins.
 
 ---
 
@@ -220,7 +233,7 @@ See [docs/PRODUCTION_DEPLOYMENT.md](./docs/PRODUCTION_DEPLOYMENT.md) for detaile
 | Cloudflare Tunnel Routes | Configured |
 | `/v1/render/*` pipeline | Shipped — card renderer + R2 cache + `@ceq/sdk` |
 | Studio auth gate | Deployed; public no-cookie app gate verified |
-| K8s Secrets | Wired in manifests and confirmed through token exchange behavior (`invalid_grant` for bogus code, indicating Janua secret is accepted) |
+| Runtime secret state | K8s Secret exists and fallback GitHub sync is refreshed; ExternalSecret remains degraded until Vault `secret/ceq.JANUA_CLIENT_SECRET` is populated |
 | Infrastructure | Live on Enclii k3s |
 
 ---
@@ -258,7 +271,9 @@ account to complete the acceptance checklist.
 | [docs/PRD.md](./docs/PRD.md) | Product requirements & manifesto |
 | [docs/PRODUCTION_DEPLOYMENT.md](./docs/PRODUCTION_DEPLOYMENT.md) | Production deployment guide |
 | [docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md](./docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md) | **Start here** — session wrap-up, doc index, operator gates |
-| [docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md](./docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md) | Repo/prod evidence audit and remaining unverified claims |
+| [docs/README.md](./docs/README.md) | Documentation map, precedence, and current truth layer |
+| [docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md](./docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md) | Current audit wrap-up, live blockers, and ROI order |
+| [docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md](./docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md) | Latest repo/prod evidence audit and remaining unverified claims |
 | [docs/GA_DEMO_DEFINITION.md](./docs/GA_DEMO_DEFINITION.md) | Capped GA demo scope, readiness scorecard, acceptance |
 | [docs/COMMERCIAL_GA_REMEDIATION_PLAN.md](./docs/COMMERCIAL_GA_REMEDIATION_PLAN.md) | Commercial GA gates, remediation tracks, pilot/launch plan |
 | [docs/COMMERCIAL_LAUNCH_READINESS_PACK.md](./docs/COMMERCIAL_LAUNCH_READINESS_PACK.md) | Commercial launch evidence, support macros, alert/compliance readiness |

--- a/docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md
+++ b/docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md
@@ -1,11 +1,13 @@
 # CEQ Identity & Capped GA Demo — Session Wrap-Up
 
-> **Last updated:** 2026-06-01
+> **Last updated:** 2026-06-02
 > **Audience:** Engineering, operators, platform agents, stakeholders  
-> **Status:** Identity wiring deployed; Studio token route accepts Janua client secret; browser credential proof captured
+> **Status:** Historical identity proof exists; current production readiness still requires ExternalSecret health, repeatable authenticated smoke, operations-status proof, and GPU golden-path proof.
 > **Readiness:** Partially demoable; Tier B still needs runtime operations-status and GPU golden-path proof ([`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md))
+> **Truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 
-This document consolidates the 2026-05-22/23 stabilization session: what was
+This document is historical context. It consolidates the 2026-05-22/23
+stabilization session: what was
 built, what Janua delivered, what operators must still run, and where every
 detail lives.
 
@@ -138,7 +140,7 @@ Execute in order. Full prompts: [`PLATFORM_AGENT_HANDOFFS.md`](./PLATFORM_AGENT_
 materialized in cluster then; `CEQ_PUBLIC_ONLY=true` production smoke green; Janua authorize 302.
 **Repo/prod audit (2026-06-01):** public smoke remains green and Studio token exchange
 with a bogus code reaches Janua as an accepted client (`invalid_grant`). See
-[`DOCS_EVIDENCE_AUDIT_2026-06-01.md`](./DOCS_EVIDENCE_AUDIT_2026-06-01.md).
+[`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md).
 
 ### Quick operator commands
 

--- a/docs/CEQ_STABILITY_ROADMAP.md
+++ b/docs/CEQ_STABILITY_ROADMAP.md
@@ -1,7 +1,8 @@
 # CEQ Stability Roadmap and Remediation Plan
 
-> **Last updated:** 2026-06-01
-> **Status:** Identity wiring deployed; Studio token route accepts Janua client secret; browser proof captured, GPU production smokes remain open
+> **Last updated:** 2026-06-02
+> **Status:** Public API/Studio health is green; historical token-route/browser proof exists; current blockers are Janua ExternalSecret degradation, missing authenticated smoke token, no live worker capacity, GPU production smoke, and non-actionable Enclii metrics/alerts.
+> **Truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 > **Session wrap-up:** [`docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md`](./CEQ_IDENTITY_AND_DEMO_WRAPUP.md)  
 > **Capped GA demo:** [`docs/GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md)  
 > **Commercial GA:** [`docs/COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md)
@@ -167,7 +168,7 @@ docs, and launch signoff. Track those in
 
 Use this as the roadmap-level priority closure board, synchronized with
 [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md)
-and `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`.
+and `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`.
 
 | Priority | Category | Action | Status | Evidence status |
 |----------|----------|--------|--------|----------------|
@@ -209,7 +210,7 @@ Engineering work landed in-repo (operator-only P0 items remain open):
 | **Phase 5** | WebSocket auth via session bootstrap | ✅ `resolveStreamAuthToken()` + async `subscribeToJob()` |
 | **Phase 6** | `ECOSYSTEM.md` drift fix | ✅ Ports, render status, Janua auth note |
 | **Phase 0** | Janua OAuth client registration | ✅ Janua registered 2026-05-23; CEQ secret mount in `studio-deployment.yaml` |
-| **Phase 0** | Studio token secret + browser proof | ✅ Token route proof green; browser proof captured via `/api/auth/session` |
+| **Phase 0** | Studio token secret + browser proof | ⚠️ Historical token/browser proof exists; current gate is healthy Vault-backed ExternalSecret and repeatable authenticated smoke |
 | **Phase 1** | Production callback/webhook secrets | ⏳ Operator — verify via `operations/status` |
 | **Phase 2** | Authenticated GPU smokes | ⏳ Blocked on Phase 1 |
 | **Phase 4** | Studio Docker regression CI gate | ✅ Closed 2026-05-22 |
@@ -260,10 +261,10 @@ Current planning estimate:
 | Milestone | Readiness | Notes |
 |-----------|-----------|-------|
 | Public technical demo | Ready now | Public edge and API evidence are green |
-| Capped GA demo | ~55-65% | Browser login, template seeding, and one GPU golden path remain open |
+| Capped GA demo | ~55-65% | Public smoke and templates are green; ExternalSecret health, authenticated smoke, operations-status, and one GPU golden path remain open |
 | Full stability | ~50-60% | Strict smoke, alert routing, and governance remain open |
 | Limited commercial pilot | ~50-60% | Credit/entitlement/queue/metering primitives landed; needs funded balances, GPU proof, support workflow |
-| Commercial GA | ~47% | Needs Dhanam billing, prod GPU proof, and alert/support/legal launch pack |
+| Commercial GA | ~55-65% of the way | Needs Dhanam billing, entitlement proof, prod GPU proof, actionable observability, and alert/support/legal launch pack |
 
 Commercial GA gates:
 

--- a/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
+++ b/docs/COMMERCIAL_GA_REMEDIATION_PLAN.md
@@ -1,19 +1,23 @@
 # CEQ Commercial GA Remediation and Implementation Plan
 
-> **Last updated:** 2026-06-01
+> **Last updated:** 2026-06-02
 > **Audience:** Product, engineering, platform, operators, support
-> **Status:** Planning baseline. CEQ is not commercially GA yet.
-> **Related:** [`DOCS_EVIDENCE_AUDIT_2026-06-01.md`](./DOCS_EVIDENCE_AUDIT_2026-06-01.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md), [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md), [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md), [`COMMERCIAL_LAUNCH_READINESS_PACK.md`](./COMMERCIAL_LAUNCH_READINESS_PACK.md)
+> **Status:** Planning baseline. CEQ is live for public demo surfaces but is not commercially GA.
+> **Truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
+> **Related:** [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md), [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md), [`COMMERCIAL_LAUNCH_READINESS_PACK.md`](./COMMERCIAL_LAUNCH_READINESS_PACK.md)
 
 ---
 
 ## Executive Summary
 
-CEQ can support a technical demo today and is on track for a capped GA demo once
-browser login, runtime secrets, and one authenticated GPU golden path are proven.
+CEQ can support a public technical demo today and is on track for a capped GA
+demo once repeatable authenticated smoke, runtime secret health, and one
+authenticated GPU golden path are proven.
 That is not the same as commercial GA.
 
-**Commercial GA distance:** approximately **48%** as of this audit.
+**Commercial GA readiness:** approximately **55-65% of the way to commercial
+GA** as of the 2026-06-02 evidence audit. This is an evidence-weighted planning
+estimate, not a launch declaration.
 
 - Technical demo and infrastructure readiness: ~100% (live evidence)
 - Capped GA readiness: ~68%
@@ -30,37 +34,38 @@ mostly productization and operations: billing/credits, entitlement enforcement,
 quota and abuse controls, support readiness, alert routing, and repeatable GPU
 capacity proof.
 
-Planning readiness as of 2026-06-01:
+Planning readiness as of 2026-06-02:
 
 | Milestone | Planning readiness | Basis |
 |-----------|--------------------|-------|
 | Public technical demo | Ready now | Public smoke green; landing/API live |
-| Capped GA demo | ~55-65% | Identity token route and browser login proof are now green; seeded-catalog and GPU proof remain open |
-| Full stability | ~50-60% | Core runtime is implemented; strict prod smoke still open |
+| Capped GA demo | ~55-65% | Public surfaces are green; ExternalSecret health, authenticated smoke, operations-status, and GPU proof remain open |
+| Full stability | ~50-60% | Core runtime is implemented; strict prod smoke, worker capacity, and actionable observability remain open |
 | Limited commercial pilot | ~50-60% | Credit/entitlement/queue/metering primitives landed; needs funded balances, GPU proof, and one supportable cohort |
 | Commercial GA | ~45-55% | Needs Dhanam billing, prod GPU proof, alert/support/legal launch pack |
 
 These percentages are planning estimates, not automated measurements. Evidence
-sources are the 2026-06-01 prod audit, `CEQ_PUBLIC_ONLY=true scripts/production-smoke.sh`,
+sources are the 2026-06-02 prod audit, `CEQ_PUBLIC_ONLY=true scripts/production-smoke.sh`,
 local test matrix, and current code/docs state. The latest fully successful
-unauthenticated endpoint matrix snapshot is `ops/evidence/2026-06-02-live-public-matrix.csv`;
+unauthenticated endpoint matrix snapshot is `ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv`;
 the previous successful snapshot is `ops/evidence/2026-06-02T021322Z-public-prod-endpoints.csv`.
 Earlier successful reruns remain as `ops/evidence/2026-06-01T221752Z-public-prod-endpoints.csv`,
 `ops/evidence/2026-06-01T221058Z-public-prod-endpoints.csv`,
 `ops/evidence/2026-06-01T2200-public-prod-endpoints.csv`, and
 `ops/evidence/2026-06-01T212236Z-public-prod-endpoints.csv`.
 
-### Evidence-weighted GA Score (2026-06-01)
+### Evidence-weighted GA Score (2026-06-02)
 
 | GA scope | Weight | Evidence status | Latest evidence |
 |----------|--------|----------------|----------------|
-| Capped GA demo | 30% | 52% | Browser login proof is now captured in production; operations/authenticated GPU path remains unproven in prod. |
+| Capped GA demo | 30% | 55-65% | Public smoke and health are green; ExternalSecret health, authenticated smoke, operations-status, and GPU proof remain unproven in prod. |
 | Full stability | 25% | 52% | Public smoke is green; alert/rollback drill + strict CI gate still pending. |
 | Limited commercial pilot | 25% | 40% | Credits API + billing source exist, but route has no confirmed live auth flow and entitlements are role/entitlement-claim aware. |
-| Commercial GA | 20% | 43% | Product/legal/operations launch controls are drafted, not yet fully proven in production. |
+| Commercial GA | 20% | 55-65% of the way | Product/legal/operations launch controls are drafted; billing, entitlement, support, observability, and GPU proof are not fully proven in production. |
 
-Estimated aggregate readiness remains **48%** (evidence-weighted). This is a
-single-source readiness value, not a prediction of time to GA.
+Estimated aggregate readiness is **55-65% of the way to commercial GA**
+(evidence-weighted). This is a planning estimate, not a prediction of time to GA
+or a launch declaration.
 
 ### GA-Critical Execution Register (as-of 2026-06-01)
 
@@ -70,7 +75,7 @@ Use this registry as the canonical closure board for GA-blocking work.
 |----------|--------|-------|--------|------------------|
 | P0-1 | Capture real browser login proof on `app.ceq.lol` with authenticated session bootstrap (`/api/auth/session`, httpOnly cookies, Studio shell load). | Studio + Janua operator | **Complete** | `2026-06-01`: `GET /api/auth/session` returned `user`, `roles`, and `access_token` for `admin@madfam.io`; `ceq_access_token` + `ceq_refresh_token` cookies were present and `httpOnly`; Studio shell route was loaded. |
 | P0-2 | Run `GET /v1/operations/status` with admin JWT and capture callback/webhook/migration/dead-letter readiness. | Platform + API | **In progress** | API JWKS fallback now proceeds to introspection when local JWT claims are incomplete. `POST /api/auth/session` is now proven in prod; production admin `operations/status` capture still pending. |
-| P0-3 | Seed and verify non-empty `/v1/templates/` in production; record stable template UUIDs for smoke runs. | Platform + API | **In progress** (`/v1/templates/` returns seeded catalog in latest evidence snapshot, including `94df20ca-280f-43a1-baa9-1c8b3f4eae48`) | `ops/evidence/2026-06-02-live-public-matrix.csv` |
+| P0-3 | Seed and verify non-empty `/v1/templates/` in production; record stable template UUIDs for smoke runs. | Platform + API | **In progress** (`/v1/templates/` returns seeded catalog in latest evidence snapshot, including `94df20ca-280f-43a1-baa9-1c8b3f4eae48`) | `ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv` |
 | P0-4 | Run authenticated GPU golden path smoke (`job → callback → output → gallery`) and capture output URL trail. | API + Workers + Platform | **Not started** | Not yet captured |
 | P0-5 | Run active cancellation + multi-modal smoke under `CEQ_STRICT_SMOKE=true` with dead-letter threshold checks. | API + Workers | **Not started** | Not yet captured |
 | P1-1 | Finalize Dhanam-backed plan/checkout path for paid signup and plan changes. | Product + Dhanam + API | **In progress** | Studio checkout bridge now targets Dhanam catalog product `ceq`; enablement still requires entitlement source proof |
@@ -80,7 +85,7 @@ Use this registry as the canonical closure board for GA-blocking work.
 | P1-5 | Confirm alert + rollback drill evidence, link synthetic alert path, and attach runbooks to alert annotations. | Platform + Support | **Not started** | Not yet linked |
 | P1-6 | Publish and link customer-facing legal/commercial docs (terms, privacy, AUP, pricing, limits) from GA flows. | Product + Legal | **In progress** | Studio `/billing` and the redesigned landing link `/legal/{terms,privacy,acceptable-use,retention,refunds}`; legal review still required |
 | P1-7 | Publish fresh-account paid pilot rehearsal evidence (login, generation, invoice/receipt, output retrieval). | Product + Eng + Support | **Not started** | Not yet executed |
-| P2 | Reconcile roadmap/docs truth after each phase closure and archive evidence row IDs centrally. | Repo docs owners | **In progress** | `COMMERCIAL_GA_REMEDIATION_PLAN.md`, `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`, `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md` |
+| P2 | Reconcile roadmap/docs truth after each phase closure and archive evidence row IDs centrally. | Repo docs owners | **In progress** | `docs/README.md`, `COMMERCIAL_GA_REMEDIATION_PLAN.md`, `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md` |
 
 ### GA-closure lanes (ROI order)
 
@@ -95,7 +100,7 @@ Track completion with these five high-impact lanes before broader closure.
 | P1-1 | Publish/verify credits balance + entitlement proof for paying cohort; attach paid pilot receipt/invoice evidence. | `In progress` |
 
 No lane is marked complete until evidence is captured, reproducible, and linked from
-`docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md` or `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`.
+`docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`.
 
 ---
 

--- a/docs/COMMERCIAL_LAUNCH_READINESS_PACK.md
+++ b/docs/COMMERCIAL_LAUNCH_READINESS_PACK.md
@@ -5,6 +5,7 @@
 > assets required for paid GA.
 > 
 > **Related:** [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md), [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md), [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md), [`PRODUCTION_DEPLOYMENT.md`](./PRODUCTION_DEPLOYMENT.md)
+> **Current truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 
 ---
 
@@ -19,7 +20,7 @@
 
 ### Evidence repository
 
-- 2026-06-01 public smoke evidence: [`ops/evidence/2026-06-01-public-prod-smoke.md`](../ops/evidence/2026-06-01-public-prod-smoke.md)
+- 2026-06-02 public smoke evidence: [`ops/evidence/2026-06-02-live-public-smoke.md`](../ops/evidence/2026-06-02-live-public-smoke.md)
   - `CEQ_PUBLIC_ONLY=true scripts/production-smoke.sh` is green (limited scope).
   - Fresh public endpoint matrix runs use:
 
@@ -27,8 +28,8 @@
 scripts/capture-public-endpoint-matrix.sh
 ```
 
-- Latest successful snapshot on record: `ops/evidence/2026-06-02-live-public-matrix.csv`
-  (earlier successful snapshots: `2026-06-02T021322Z`, `2026-06-01T221752Z`, `2026-06-01T221058Z`, `2026-06-01T224003Z`).
+- Latest successful public endpoint matrix on record:
+  [`ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv`](../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv).
 
 ### Required evidence for paid launch
 

--- a/docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md
+++ b/docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md
@@ -1,5 +1,12 @@
 # CEQ Docs Evidence Audit - 2026-06-01
 
+> **Superseded for current status:** Use
+> [`README.md`](./README.md),
+> [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md),
+> and [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
+> for current production truth. This file is retained as historical evidence
+> for the 2026-06-01 audit.
+
 This audit cross-checks CEQ documentation against the repository and public
 production endpoints. It does not use raw cluster access or real Janua user
 credentials.

--- a/docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md
+++ b/docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md
@@ -2,10 +2,12 @@
 
 This is a supplemental evidence snapshot focused on public production readiness after the latest merge window.
 
+Related: [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md), [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md).
+
 ## Public production evidence updates
 
 - `CEQ_PUBLIC_ONLY=true scripts/production-smoke.sh` result: [../ops/evidence/2026-06-02-live-public-smoke.md](../ops/evidence/2026-06-02-live-public-smoke.md)
-- `capture-public-endpoint-matrix.sh` result: [../ops/evidence/2026-06-02-live-public-matrix.csv](../ops/evidence/2026-06-02-live-public-matrix.csv)
+- `capture-public-endpoint-matrix.sh` result: [../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv](../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv)
 - `2026-06-02T04:15Z` public smoke rerun passed locally.
 - `2026-06-02T04:15Z` public endpoint matrix was captured at [../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv](../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv).
 - `GET /ready` returned `200`; unauthenticated `GET /v1/credits/balance` returned `401`; unauthenticated `GET /v1/operations/status` returned `401`.

--- a/docs/GA_DEMO_DEFINITION.md
+++ b/docs/GA_DEMO_DEFINITION.md
@@ -1,23 +1,25 @@
 # CEQ Capped GA Demo — Definition and Readiness
 
-> **Last updated:** 2026-06-01
+> **Last updated:** 2026-06-02
 > **Audience:** Product, engineering, operators, demo presenters  
+> **Truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 > **Related:** [`CEQ_IDENTITY_AND_DEMO_WRAPUP.md`](./CEQ_IDENTITY_AND_DEMO_WRAPUP.md), [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md), [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md), [`COMMERCIAL_LAUNCH_READINESS_PACK.md`](./COMMERCIAL_LAUNCH_READINESS_PACK.md), [`JANUA_OPERATOR.md`](./JANUA_OPERATOR.md), [`JANUA_AGENT_HANDOFF.md`](./JANUA_AGENT_HANDOFF.md), [`PLATFORM_AGENT_HANDOFFS.md`](./PLATFORM_AGENT_HANDOFFS.md)
 
 ---
 
 ## Executive summary
 
-CEQ is **infra-stable and partially demoable in production today**. A **capped,
-prod-quality GA demo** (real login, one golden GPU path, deterministic render
-API, InterestGate caps) is not yet declared ready because operations-status and
-authenticated GPU proof remain open.
+CEQ is **public-edge stable and partially demoable in production today**. A
+**capped, prod-quality GA demo** (repeatable authenticated smoke, one golden GPU
+path, deterministic render API, InterestGate caps) is not yet declared ready
+because ExternalSecret health, operations-status, authenticated smoke, and GPU
+proof remain open.
 
 | Milestone | Readiness | Blocker |
 |-----------|-----------|---------|
 | Public marketing + API edge | **~90%** | None |
 | Asset pillar (`/v1/render/*`, `@ceq/sdk`) | **~90%** | Needs Janua JWT for live call |
-| Authenticated Studio (`app.ceq.lol`) | **~85%** | Janua registered; token route accepts client secret; browser proof captured |
+| Authenticated Studio (`app.ceq.lol`) | **~75%** | Janua registered and historical browser/token-route proof exists; current repeatable auth smoke is blocked by missing CEQ auth token and degraded Janua ExternalSecret |
 | End-to-end GPU job in prod | **~10%** | Janua + runtime secrets + prod smokes |
 | Capped monetization (InterestGate + API guard) | **~60%** | Interest capture, premium API guard, claim-aware caps, feature-flagged render/GPU debits, and Studio balance readout shipped; checkout/pricing still open |
 | GA ops (strict smoke, alerts, branch protection) | **~45%** | Branch protection enabled; strict smoke and alert routing still open |
@@ -38,7 +40,7 @@ external stakeholders **without** claiming full PRD breadth. Caps are intentiona
 
 | Cap type | Mechanism | Status |
 |----------|-----------|--------|
-| **Identity** | Janua SSO; demo accounts only | Janua registered; Studio token route accepts client secret; browser proof captured |
+| **Identity** | Janua SSO; demo accounts only | Janua registered; historical browser/token-route proof exists; current gate is repeatable auth smoke plus healthy Vault-backed ExternalSecret |
 | **GPU throughput** | Single “golden” template + Vast.ai capacity | Not prod-proven |
 | **Templates** | 13 seeded workflow templates in repo code; production needs seed verification | Repo-seeded; prod `/v1/templates/` now returns seeded rows in public checks |
 | **Monetization** | InterestGate on pro/premium tags plus API-side premium guard (not checkout) | Shipped in code |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,6 +4,11 @@
 
 Welcome to **CEQ** — Creative Entropy Quantized. This guide will help you get started with creating AI-generated content using our streamlined ComfyUI interface.
 
+> **Production readiness note:** CEQ public surfaces are live, but CEQ is not
+> commercial GA. For current blockers and evidence, start with
+> [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md),
+> and [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md).
+
 ## What is CEQ?
 
 CEQ is a content generation platform that wraps [ComfyUI](https://github.com/comfyanonymous/ComfyUI) with a clean, hacker-friendly interface. It's designed for power users who want:

--- a/docs/JANUA_AGENT_HANDOFF.md
+++ b/docs/JANUA_AGENT_HANDOFF.md
@@ -1,6 +1,6 @@
 # Janua Agent Handoff — CEQ Studio OAuth Integration
 
-> **Last updated:** 2026-06-01  
+> **Last updated:** 2026-06-02  
 > **From:** CEQ (`madfam-org/ceq`)  
 > **To:** Janua agent / Janua operator / Enclii identity adapter owner  
 > **Priority:** P0 — blocks all authenticated CEQ value and capped GA demo  
@@ -8,12 +8,13 @@
 > **Platform agents:** [`PLATFORM_AGENT_HANDOFFS.md`](./PLATFORM_AGENT_HANDOFFS.md)  
 > **Session wrap-up:** [`CEQ_IDENTITY_AND_DEMO_WRAPUP.md`](./CEQ_IDENTITY_AND_DEMO_WRAPUP.md)  
 > **Demo context:** [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md)
+> **Current CEQ truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 
-> **2026-06-01 audit update:** Janua registration remains good. Live Studio
+> **2026-06-02 audit update:** Janua registration remains good. Historical Studio
 > token exchange with a bogus code returns Janua `invalid_grant`, not
-> `invalid_client`, which means the deployed CEQ Studio has a client secret
-> accepted by Janua. Browser login with real credentials and `/api/auth/session`
-> are captured; remaining proof is runtime secrets + GPU production smoke.
+> `invalid_client`, which means the deployed CEQ Studio had a client secret
+> accepted by Janua. Current CEQ-side blocker is Vault-backed ExternalSecret
+> health plus repeatable authenticated smoke; GPU production smoke remains open.
 
 ---
 

--- a/docs/JANUA_OPERATOR.md
+++ b/docs/JANUA_OPERATOR.md
@@ -5,6 +5,7 @@
 > **Janua-side agent:** See [`JANUA_AGENT_HANDOFF.md`](./JANUA_AGENT_HANDOFF.md) for the complete cross-repo handoff.  
 > **Platform agents (Vault/K8s/acceptance):** [`PLATFORM_AGENT_HANDOFFS.md`](./PLATFORM_AGENT_HANDOFFS.md)  
 > **Demo context:** [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md)  
+> **Current evidence:** [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 > **Enclii-first:** Register clients and rotate secrets via Enclii/Janua adapters when available. Use Janua admin only as documented break-glass and record adapter gaps.
 
 ---
@@ -23,13 +24,15 @@ Janua. Authorize returns **302** to login (not `invalid_client`).
 | §9.4 JWKS / issuer | ✅ `https://auth.madfam.io` |
 | §9.5 GET `/logout` | ⚠️ 404 — non-blocking for login; see [Logout follow-up](#logout-follow-up) |
 
-### CEQ-side (browser proof captured)
+### CEQ-side (historical browser proof captured; current secret-sync blocker)
 
 Studio token exchange requires **`JANUA_CLIENT_SECRET` at runtime**. As of
-2026-06-01:
+2026-06-02:
 
 - GitHub Actions repo secret `JANUA_CLIENT_SECRET` is set (`madfam-org/ceq`).
 - **Vault** path `secret/ceq` must include property `JANUA_CLIENT_SECRET`.
+  Current evidence says this property is missing, so ExternalSecret
+  `ceq-janua-client-secret` is `SecretSyncedError`.
 - **`external-secret.yaml`** syncs that property into the dedicated
   `ceq-janua-client-secret` Kubernetes Secret.
 - **`studio-deployment.yaml`** mounts `JANUA_CLIENT_SECRET` from
@@ -37,6 +40,9 @@ Studio token exchange requires **`JANUA_CLIENT_SECRET` at runtime**. As of
 - Live prod check: `POST https://app.ceq.lol/api/auth/token` with a bogus code
   returns Janua `invalid_grant`, not `invalid_client`, which proves the deployed
   Studio token route has a client secret accepted by Janua.
+- Fallback GitHub workflow `sync-janua-client-secret.yml` refreshed the live
+  Kubernetes Secret successfully on 2026-06-02, but that does not populate Vault
+  and does not make the ExternalSecret healthy.
 
 Remaining acceptance: browser proof has been captured with real credentials and
 `/api/auth/session`; remaining non-blocking follow-up is logout + refresh hardening.

--- a/docs/PLATFORM_AGENT_HANDOFFS.md
+++ b/docs/PLATFORM_AGENT_HANDOFFS.md
@@ -1,17 +1,17 @@
 # Platform Agent Handoffs — CEQ Studio Login Unblock
 
-> **Last updated:** 2026-06-01
-> **Goal:** Complete CEQ Tier B demo identity gate — real login on `app.ceq.lol`  
+> **Last updated:** 2026-06-02
+> **Goal:** Complete CEQ Tier B demo runtime gates: Vault-backed Janua ExternalSecret, repeatable authenticated smoke, operations status, and GPU proof.
 > **CEQ repo state:** `main` branch state reflected in active commercial GA remediation notes (CI green; K8s wiring on main)
 > **Janua P0:** ✅ OAuth client registered (`jnc_2EJwBz8xGVsGYOO2r3ck5CJH7YrQw4Yk`, authorize 302)  
-> **CEQ engineering P0:** ✅ K8s manifests wired; ✅ live Studio token route accepts Janua client secret (2026-06-01); browser proof captured (2026-06-01)
+> **CEQ engineering P0:** K8s manifests wired and fallback K8s Secret sync refreshed; current blocker is Vault-backed ExternalSecret health plus authenticated smoke.
+> **Truth layer:** [`README.md`](./README.md), [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md), [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
 
-> **2026-06-01 audit update:** Live `POST https://app.ceq.lol/api/auth/token`
-> with a bogus authorization code returns Janua `invalid_grant`, not
-> `invalid_client`, so the deployed Studio token route has a Janua client secret
-> accepted by production Janua. Browser login proof is also captured for
-> `admin@madfam.io`; remaining P0 work is runtime operations status and GPU
-> proof.
+> **2026-06-02 audit update:** Public smoke is green and `ceq-api`/`ceq-studio`
+> are healthy, but ExternalSecret `ceq-janua-client-secret` is degraded because
+> Vault `secret/ceq.JANUA_CLIENT_SECRET` is missing. The GitHub fallback sync
+> refreshed the Kubernetes Secret but did not populate Vault. Authenticated
+> smoke remains blocked on a real CEQ auth/admin token; GPU proof remains open.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -11,7 +11,7 @@
 > **Philosophy**: *Wrestling order from the chaos of latent space*
 
 > For current production evidence, deployment state, and remaining gates, use
-> [`DOCS_EVIDENCE_AUDIT_2026-06-01.md`](./DOCS_EVIDENCE_AUDIT_2026-06-01.md),
+> [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md),
 > [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md), and
 > [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md). For paid launch scope and
 > commercial GA gates, use

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -10,6 +10,11 @@
 
 > Deploy CEQ to production at ceq.lol via Enclii infrastructure
 
+> **Current truth:** For live readiness, read [`README.md`](./README.md),
+> [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md),
+> and [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md)
+> before relying on older checklist rows.
+
 ## Prerequisites
 
 - Access to Cloudflare Zero Trust dashboard
@@ -19,11 +24,12 @@
 - GitHub repo write access for secrets
 - Terraform installed (`brew install terraform`)
 
-## Deployment Status (2026-06-01)
+## Deployment Status (2026-06-02)
 
 | Step | Status | Notes |
 |------|--------|-------|
-| Janua OAuth Client | Done (2026-05-23) | Client registered; Studio token route returns `invalid_grant` for a bogus code, proving the client secret is mounted and accepted |
+| Janua OAuth Client | Partially done | Client registered; historical token-route proof returned `invalid_grant`, but current repeatable authenticated smoke is blocked on a real CEQ token |
+| Janua ExternalSecret | Degraded | `ceq-janua-client-secret` Secret exists, but ExternalSecret is `SecretSyncedError` until Vault `secret/ceq.JANUA_CLIENT_SECRET` is populated |
 | Cloudflare Tunnel Routes | Done | ceq.lol, app.ceq.lol, api.ceq.lol, ws.ceq.lol |
 | R2 Bucket + Token | Done | `ceq-assets` with Object Read & Write |
 | secrets.local.yaml | Done | R2 + OAuth done, DB/Redis configured |
@@ -32,7 +38,7 @@
 | Redis Password | Done | Redis configured |
 | GitHub Actions Secret | Done | KUBECONFIG_BASE64 applied |
 | Studio Auth Gate | Done | `app.ceq.lol` no-cookie gate verified with public smoke |
-| Deploy + Verify | Done | GitOps deploy `25853708026` succeeded; digest commit `1eaf6a6` |
+| Deploy + Verify | Public-only done | Public smoke passed; strict authenticated smoke and GPU golden path remain open |
 
 Commercial GA is not declared by this deployment checklist. Paid launch still
 requires billing, credits, server-side entitlements, quotas, support, and launch

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,84 @@
+# CEQ documentation map
+
+This is the navigation and truth layer for CEQ documentation. Use it before
+trusting older roadmap, handoff, or deployment notes.
+
+## Current truth sources
+
+| Document | Use it for |
+|---|---|
+| [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md) | Current audit summary, remediations, live blockers, and recommended ROI order |
+| [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md) | Evidence-backed production facts from public smoke, Enclii, GitHub, Kubernetes, policy, and observability checks |
+| [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md) | Capped GA demo scope and proof requirements |
+| [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md) | Commercial GA gates and paid-launch remediation plan |
+| [`COMMERCIAL_LAUNCH_READINESS_PACK.md`](./COMMERCIAL_LAUNCH_READINESS_PACK.md) | Paid-launch evidence pack, support checklist, legal/commercial readiness |
+
+## Current status in one paragraph
+
+CEQ has live public surfaces and passing public no-auth smoke. `ceq-api` and
+`ceq-studio` are healthy in Enclii health at 2/2 ready pods, and `/ready`
+returns 200. CEQ is not commercial GA: the Janua ExternalSecret is degraded
+because Vault is missing `secret/ceq.JANUA_CLIENT_SECRET`, authenticated smoke
+is blocked on a real CEQ auth/admin token, worker/GPU golden-path proof is not
+captured, Enclii metrics/alerts are not actionable, and billing/entitlements are
+not paid-launch proven.
+
+## Documentation precedence
+
+When documents conflict, prefer this order:
+
+1. Latest evidence audit, currently [`DOCS_EVIDENCE_AUDIT_2026-06-02.md`](./DOCS_EVIDENCE_AUDIT_2026-06-02.md).
+2. Latest wrap-up, currently [`CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`](./CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md).
+3. Active plans: [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md), [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md), [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md).
+4. Operator and handoff docs, which may include historical context.
+5. Legacy embedded sections in [`AGENTS.md`](../AGENTS.md), [`ECOSYSTEM.md`](../ECOSYSTEM.md), and older session wrap-ups.
+
+## Product and launch docs
+
+| Document | Role |
+|---|---|
+| [`GA_DEMO_DEFINITION.md`](./GA_DEMO_DEFINITION.md) | Defines Tier A/B/C demo scope and acceptance gates |
+| [`COMMERCIAL_GA_REMEDIATION_PLAN.md`](./COMMERCIAL_GA_REMEDIATION_PLAN.md) | Tracks the work needed to sell, meter, support, and operate CEQ commercially |
+| [`COMMERCIAL_LAUNCH_READINESS_PACK.md`](./COMMERCIAL_LAUNCH_READINESS_PACK.md) | Collects evidence, support, legal, and alert-readiness launch artifacts |
+| [`PRD.md`](./PRD.md) | Product requirements and broader ambition |
+| [`LANDING_CONVERSION_AUDIT_2026-06-02.md`](./LANDING_CONVERSION_AUDIT_2026-06-02.md) | Landing-page conversion findings |
+
+## Operations and identity docs
+
+| Document | Role |
+|---|---|
+| [`JANUA_OPERATOR.md`](./JANUA_OPERATOR.md) | CEQ-side Janua operator checklist and current identity blockers |
+| [`JANUA_AGENT_HANDOFF.md`](./JANUA_AGENT_HANDOFF.md) | Janua-side handoff and OAuth coordination notes |
+| [`PLATFORM_AGENT_HANDOFFS.md`](./PLATFORM_AGENT_HANDOFFS.md) | Platform/Vault/Kubernetes/acceptance handoff prompts and known adapter gaps |
+| [`PRODUCTION_DEPLOYMENT.md`](./PRODUCTION_DEPLOYMENT.md) | Production deployment guide; contains legacy raw commands and must be read Enclii-first |
+| [`CEQ_STABILITY_ROADMAP.md`](./CEQ_STABILITY_ROADMAP.md) | Stability roadmap, smoke matrix, critical path, and historical closure record |
+
+## Developer docs
+
+| Document | Role |
+|---|---|
+| [`GETTING_STARTED.md`](./GETTING_STARTED.md) | Product and developer quick start |
+| [`API.md`](./API.md) | API reference |
+| [`TEMPLATES.md`](./TEMPLATES.md) | Template catalog and render API notes |
+| [`VAST_AI_SETUP.md`](./VAST_AI_SETUP.md) | GPU provider setup notes |
+
+## Evidence artifacts
+
+Evidence files live under [`../ops/evidence`](../ops/evidence). The most recent
+public production evidence from the 2026-06-02 audit includes:
+
+- [`../ops/evidence/2026-06-02-live-public-smoke.md`](../ops/evidence/2026-06-02-live-public-smoke.md)
+- [`../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv`](../ops/evidence/2026-06-02T041548Z-public-prod-endpoints.csv)
+
+## Claim hygiene rules
+
+- Do not mark CEQ commercial GA until billing, entitlements, quotas, support,
+  alerting, and authenticated render proof are captured.
+- Do not treat a present Kubernetes Secret as a healthy ExternalSecret; verify
+  the ExternalSecret condition and Vault source.
+- Do not treat public smoke as authenticated smoke.
+- Do not treat mocked Janua Playwright tests as live browser-login proof.
+- Do not treat a deployed worker manifest as worker capacity; verify live worker
+  pods and a successful job path.
+- When raw infrastructure access is used because Enclii lacks an adapter, record
+  the adapter gap in the relevant evidence doc.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Ceq Full LLM Context
 
-Generated: 2026-05-13
+Generated: 2026-06-02
 
 ## Purpose
 
@@ -37,8 +37,10 @@ gap or incident link.
 
 - `README.md`
 - `ECOSYSTEM.md`
+- `docs/README.md`
+- `docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md`
+- `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md`
 - `docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md`
-- `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md`
 - `docs/CEQ_STABILITY_ROADMAP.md`
 - `docs/GA_DEMO_DEFINITION.md`
 - `docs/COMMERCIAL_GA_REMEDIATION_PLAN.md`

--- a/llms.txt
+++ b/llms.txt
@@ -7,8 +7,10 @@ Compact LLM context index for this repository.
 - `AGENTS.md` — canonical agent operating instructions.
 - `README.md` — human/product overview when present.
 - `ECOSYSTEM.md` — MADFAM ecosystem and Enclii deployment context when present.
+- `docs/README.md` — documentation map, precedence, and current truth layer.
+- `docs/CEQ_CODEBASE_AUDIT_WRAPUP_2026-06-02.md` — latest audit wrap-up and ROI-prioritized blockers.
+- `docs/DOCS_EVIDENCE_AUDIT_2026-06-02.md` — current repo/prod evidence audit and remaining unverified claims.
 - `docs/CEQ_IDENTITY_AND_DEMO_WRAPUP.md` — session wrap-up, doc index, operator gates.
-- `docs/DOCS_EVIDENCE_AUDIT_2026-06-01.md` — current repo/prod evidence audit and remaining unverified claims.
 - `docs/CEQ_STABILITY_ROADMAP.md` — stabilization phases, smoke matrix, remaining gates.
 - `docs/GA_DEMO_DEFINITION.md` — capped GA demo definition, readiness scorecard, Tier A/B/C.
 - `docs/COMMERCIAL_GA_REMEDIATION_PLAN.md` — paid launch gates, remediation tracks, commercial GA declaration criteria.


### PR DESCRIPTION
## Summary
- add docs/README.md as the central documentation map and precedence guide
- link top-level, LLM, agent, product, ops, and handoff docs to the 2026-06-02 truth layer
- qualify stale auth, GA, worker, observability, and ExternalSecret claims
- mark the 2026-06-01 evidence audit as historical/superseded

## Tests
- not run locally; docs-only change
- no test fixtures/assertions referenced these documentation claims, so no test updates were applicable