### PR TITLE
docs: align GA demo guidance

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -73,7 +73,7 @@ below is embedded here so this document stands alone.
 | **Enclii** | `madfam-org/enclii` | PaaS control plane — all deploys go through this |
 | **Janua** | `madfam-org/janua` | OIDC/OAuth 2.0 provider — RS256 JWKS at `auth.madfam.io/.well-known/jwks.json` |
 | **Dhanam** | `madfam-org/dhanam` | Billing + payment gateways (Stripe, Mercado Pago, SPEI, etc.) |
-| **Selva** | `madfam-org/autoswarm-office` | LLM inference routing + agent orchestration |
+| **Selva** | `madfam-org/selva-office` | LLM inference routing + agent orchestration |
 | **Karafiel** | `madfam-org/karafiel` | Operational compliance — CFDI, NOM-151, e.firma, SAT-adjacent. Owns legal-ops / contract templates |
 | **Tezca** | `madfam-org/tezca` | Mexican law oracle (informational only — feeds Karafiel) |
 | **Cotiza** | `madfam-org/digifab-quoting` | MADFAM's quoting engine (fabrication + services) |
@@ -91,7 +91,7 @@ below is embedded here so this document stands alone.
 - **Billing**: credit metering + entitlements flow through Dhanam. See
   `madfam-org/dhanam` for the meter/entitlement/invoice APIs.
 - **Inference**: every LLM call should route through Selva
-  (`autoswarm-office`) at `/v1` (OpenAI-compatible). Do not talk directly
+  (`selva-office`) at `/v1` (OpenAI-compatible). Do not talk directly
   to OpenAI / Anthropic from service code.
 - **CORS**: explicit allowlist per service. Wildcards are banned
   (audit 2026-04-23 H2/H5/H6).

--- a/docs/GA_DEMO_DEFINITION.md
+++ b/docs/GA_DEMO_DEFINITION.md
@@ -50,7 +50,7 @@ external stakeholders **without** claiming full PRD breadth. Caps are intentiona
 
 **GA quality bar** for this demo means:
 
-- No manual `kubectl apply` for routine deploys (GitOps + CI gates)
+- No `kubectl apply` for routine deploys; use GitOps + CI gates instead
 - Public smoke green on every release candidate
 - Real browser login and session cookies on `app.ceq.lol`
 - At least one job: submit → queue → worker → R2 → callback → PostgreSQL → gallery

--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -57,25 +57,3 @@ spec:
         key: secret/ceq
         property: FURNACE_API_KEY
 ---
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: ceq-janua-client-secret
-  namespace: ceq
-  labels:
-    app: ceq
-    component: studio-auth
-spec:
-  refreshInterval: 15m
-  secretStoreRef:
-    name: vault-store
-    kind: ClusterSecretStore
-  target:
-    name: ceq-janua-client-secret
-    creationPolicy: Owner
-    deletionPolicy: Retain
-  data:
-    - secretKey: JANUA_CLIENT_SECRET
-      remoteRef:
-        key: secret/ceq
-        property: JANUA_CLIENT_SECRET


### PR DESCRIPTION
Updates GA demo guidance to comply with the Enclii-first operating model and carries existing local main commits that were already ahead of origin/main.\n\nValidation: git diff --check