### PR TITLE
fix(k8s): in-cluster Janua JWKS + janua egress for API auth

### DIFF
--- a/apps/api/tests/test_k8s_manifests.py
+++ b/apps/api/tests/test_k8s_manifests.py
@@ -13,7 +13,7 @@ JANUA_JWT_ENV = (
 )
 
 JANUA_JWT_VALUES = (
-    'value: "https://auth.madfam.io/.well-known/jwks.json"',
+    'value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"',
     'value: "https://auth.madfam.io"',
     'value: "ceq-api"',
 )
@@ -88,3 +88,11 @@ def test_migration_job_has_full_production_runtime_env() -> None:
 
     assert 'value: "http://janua-api.janua.svc.cluster.local:4100"' in manifest
     assert "optional: true" not in manifest
+
+
+def test_network_policy_allows_janua_egress() -> None:
+    manifest = (REPO_ROOT / "infrastructure/k8s/network-policies.yaml").read_text()
+
+    assert "name: allow-janua-egress" in manifest
+    assert "kubernetes.io/metadata.name: janua" in manifest
+    assert "port: 4100" in manifest

--- a/infrastructure/k8s/api-deployment.yaml
+++ b/infrastructure/k8s/api-deployment.yaml
@@ -77,8 +77,10 @@ spec:
                   key: JOB_WEBHOOK_SECRET
             - name: JANUA_API_URL
               value: "http://janua-api.janua.svc.cluster.local:4100"
+            # In-cluster JWKS: Cloudflare returns 403 to Hetzner pod egress on the
+            # public auth.madfam.io URL; Janua serves the same keys internally.
             - name: JANUA_JWKS_URL
-              value: "https://auth.madfam.io/.well-known/jwks.json"
+              value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"
             - name: JANUA_ISSUER
               value: "https://auth.madfam.io"
             - name: JANUA_AUDIENCE

--- a/infrastructure/k8s/db-migrate-job.yaml
+++ b/infrastructure/k8s/db-migrate-job.yaml
@@ -121,7 +121,7 @@ spec:
             - name: JANUA_API_URL
               value: "http://janua-api.janua.svc.cluster.local:4100"
             - name: JANUA_JWKS_URL
-              value: "https://auth.madfam.io/.well-known/jwks.json"
+              value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"
             - name: JANUA_ISSUER
               value: "https://auth.madfam.io"
             - name: JANUA_AUDIENCE

--- a/infrastructure/k8s/network-policies.yaml
+++ b/infrastructure/k8s/network-policies.yaml
@@ -73,3 +73,22 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
+---
+# Janua SSO + in-cluster JWKS/introspection (default-deny blocks cross-namespace).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-janua-egress
+  namespace: ceq
+spec:
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: janua
+    ports:
+    - port: 4100
+      protocol: TCP
+  podSelector: {}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
## Summary
- Point `JANUA_JWKS_URL` at in-cluster Janua (`janua-api.janua:4100`) — Cloudflare returns 403 to Hetzner pod egress on the public JWKS URL
- Add `allow-janua-egress` NetworkPolicy (port 4100) so JWKS fetch and introspection fallback can reach Janua
- Regression tests for manifest contract

## Evidence
Production `ceq-api` logs after rollout restart showed:
- `JWKS client initialized: https://auth.madfam.io/.well-known/jwks.json`
- `JWKS fetch failed ... HTTP Error 403: Forbidden`
- `Failed to connect to Janua API: All connection attempts failed`

## Test plan
- [x] `test_k8s_manifests.py` updated
- [ ] CI green
- [ ] Post-merge: Argo sync `ceq-services` + verify `GET /v1/credits/balance` returns 200 with Janua JWT

Made with [Cursor](https://cursor.com)