### PR TITLE
fix(k8s): Janua service port 80 for JWKS and API introspection

### DIFF
--- a/apps/api/tests/test_k8s_manifests.py
+++ b/apps/api/tests/test_k8s_manifests.py
@@ -13,7 +13,7 @@ JANUA_JWT_ENV = (
 )
 
 JANUA_JWT_VALUES = (
-    'value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"',
+    'value: "http://janua-api.janua.svc.cluster.local/.well-known/jwks.json"',
     'value: "https://auth.madfam.io"',
     'value: "ceq-api"',
 )
@@ -86,7 +86,7 @@ def test_migration_job_has_full_production_runtime_env() -> None:
     ):
         assert f"- name: {name}" in manifest
 
-    assert 'value: "http://janua-api.janua.svc.cluster.local:4100"' in manifest
+    assert 'value: "http://janua-api.janua.svc.cluster.local"' in manifest
     assert "optional: true" not in manifest
 
 
@@ -95,4 +95,4 @@ def test_network_policy_allows_janua_egress() -> None:
 
     assert "name: allow-janua-egress" in manifest
     assert "kubernetes.io/metadata.name: janua" in manifest
-    assert "port: 4100" in manifest
+    assert "port: 8080" in manifest

--- a/infrastructure/k8s/api-deployment.yaml
+++ b/infrastructure/k8s/api-deployment.yaml
@@ -76,11 +76,11 @@ spec:
                   name: ceq-secrets
                   key: JOB_WEBHOOK_SECRET
             - name: JANUA_API_URL
-              value: "http://janua-api.janua.svc.cluster.local:4100"
-            # In-cluster JWKS: Cloudflare returns 403 to Hetzner pod egress on the
-            # public auth.madfam.io URL; Janua serves the same keys internally.
+              value: "http://janua-api.janua.svc.cluster.local"
+            # In-cluster JWKS: public auth.madfam.io returns 403 from cluster egress;
+            # Janua Service is port 80 -> pod 8080 (not 4100).
             - name: JANUA_JWKS_URL
-              value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"
+              value: "http://janua-api.janua.svc.cluster.local/.well-known/jwks.json"
             - name: JANUA_ISSUER
               value: "https://auth.madfam.io"
             - name: JANUA_AUDIENCE

--- a/infrastructure/k8s/db-migrate-job.yaml
+++ b/infrastructure/k8s/db-migrate-job.yaml
@@ -119,9 +119,9 @@ spec:
                   name: ceq-secrets
                   key: JOB_WEBHOOK_SECRET
             - name: JANUA_API_URL
-              value: "http://janua-api.janua.svc.cluster.local:4100"
+              value: "http://janua-api.janua.svc.cluster.local"
             - name: JANUA_JWKS_URL
-              value: "http://janua-api.janua.svc.cluster.local:4100/.well-known/jwks.json"
+              value: "http://janua-api.janua.svc.cluster.local/.well-known/jwks.json"
             - name: JANUA_ISSUER
               value: "https://auth.madfam.io"
             - name: JANUA_AUDIENCE

--- a/infrastructure/k8s/network-policies.yaml
+++ b/infrastructure/k8s/network-policies.yaml
@@ -87,7 +87,7 @@ spec:
         matchLabels:
           kubernetes.io/metadata.name: janua
     ports:
-    - port: 4100
+    - port: 8080
       protocol: TCP
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
## Summary
- Point `JANUA_API_URL` / `JANUA_JWKS_URL` at `janua-api.janua.svc.cluster.local` (Service port 80 → pod 8080)
- Fix `allow-janua-egress` NetworkPolicy to target pod port 8080

## Root cause
Production logs showed JWKS 403 on public URL; after switching to `:4100` internal URL, auth still failed because Janua Service exposes **port 80**, not 4100.

## Test plan
- [ ] CI green
- [ ] Post-merge + GitOps sync: authenticated `GET /v1/credits/balance` returns 200

Made with [Cursor](https://cursor.com)