### PR TITLE
fix(studio): restore reliable local typecheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 out/
 *.js.map
 *.d.ts
+!apps/studio/next-env.d.ts
 
 # IDE
 .idea/

--- a/apps/studio/__tests__/components/marketing-landing.test.tsx
+++ b/apps/studio/__tests__/components/marketing-landing.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/contexts/auth-context", () => ({
     user: null,
     isAuthenticated: false,
     isLoading: false,
+    isApiAuthorized: null,
     token: null,
     logout: vi.fn(),
     refreshToken: vi.fn(),

--- a/apps/studio/next-env.d.ts
+++ b/apps/studio/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e"]
 }


### PR DESCRIPTION
## Summary
- Commit `next-env.d.ts` (was blocked by root `*.d.ts` gitignore)
- Exclude `e2e/` from studio `tsc` (Playwright has its own toolchain)
- Add `isApiAuthorized` to marketing-landing auth mock

## Test plan
- [x] `pnpm --filter @ceq/studio typecheck`
- [x] vitest user-menu + marketing-landing tests

Made with [Cursor](https://cursor.com)