### PR TITLE
fix(k8s): split orchestrator secrets, scale GPU worker to 0

### DIFF
--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -56,6 +56,24 @@ spec:
       remoteRef:
         key: secret/ceq
         property: FURNACE_API_KEY
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ceq-orchestrator-secrets
+  namespace: ceq
+  labels:
+    app: ceq-orchestrator
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    name: vault-store
+    kind: ClusterSecretStore
+  target:
+    name: ceq-orchestrator-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
     - secretKey: VAST_API_KEY
       remoteRef:
         key: secret/ceq

--- a/infrastructure/k8s/worker-orchestrator-deployment.yaml
+++ b/infrastructure/k8s/worker-orchestrator-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
     ceq.madfam.io/compute-strategy: "vast-external"
     ceq.madfam.io/docs: "docs/GPU_COMPUTE_STRATEGY.md"
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: ceq-orchestrator
@@ -65,18 +65,18 @@ spec:
             - name: CEQ_WORKER_REDIS_URL
               valueFrom:
                 secretKeyRef:
-                  name: ceq-secrets
+                  name: ceq-orchestrator-secrets
                   key: CEQ_WORKER_REDIS_URL
                   optional: true
             - name: VAST_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ceq-secrets
+                  name: ceq-orchestrator-secrets
                   key: VAST_API_KEY
             - name: FAL_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ceq-secrets
+                  name: ceq-orchestrator-secrets
                   key: FAL_API_KEY
                   optional: true
             - name: R2_ENDPOINT


### PR DESCRIPTION
## Summary
- Move VAST/FAL/worker Redis keys to `ceq-orchestrator-secrets` ExternalSecret
- Scale `ceq-orchestrator` to 0 until Vault has `VAST_API_KEY`
- Restores `ceq-secrets` ESO Ready state

## Test plan
- [ ] `ceq-secrets` ExternalSecret Ready=True
- [ ] Argo ceq-services health Healthy

Made with [Cursor](https://cursor.com)