### PR TITLE
fix(k8s): ignore Argo health on blocked CEQ ExternalSecrets

### DIFF
--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -64,6 +64,9 @@ metadata:
   namespace: ceq
   labels:
     app: ceq-orchestrator
+  annotations:
+    # Orchestrator is intentionally scaled to 0 until Vault has VAST/FAL keys.
+    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   refreshInterval: 15m
   secretStoreRef:
@@ -94,6 +97,10 @@ metadata:
   namespace: ceq
   labels:
     app: ceq
+  annotations:
+    # Break-glass: live K8s secret is populated; Vault secret/ceq.JANUA_CLIENT_SECRET
+    # backfill is tracked in internal-devops runbooks until ESO is Ready again.
+    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   refreshInterval: 15m
   secretStoreRef:


### PR DESCRIPTION
Unblocks ceq-services Argo health until Vault secret/ceq is backfilled.

Made with [Cursor](https://cursor.com)