### PR TITLE
fix(k8s): bridge Janua client secret via kubernetes-store

### DIFF
--- a/infrastructure/k8s/ceq-kubernetes-secretstore.yaml
+++ b/infrastructure/k8s/ceq-kubernetes-secretstore.yaml
@@ -1,0 +1,28 @@
+---
+# Kubernetes-backed secret source for CEQ namespace bridge secrets.
+#
+# Interim until Vault secret/ceq is fully backfilled (JANUA_CLIENT_SECRET and
+# orchestrator keys). Bridge secrets (*-source) are populated out-of-band; see
+# enclii/scripts/ga-ceq-bridge-bootstrap.sh.
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: ceq-kubernetes-store
+  labels:
+    app.kubernetes.io/name: ceq
+    app.kubernetes.io/part-of: madfam-platform
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: ceq
+      server:
+        url: kubernetes.default
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets

--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -97,22 +97,18 @@ metadata:
   namespace: ceq
   labels:
     app: ceq
-  annotations:
-    # Break-glass: live K8s secret is populated; Vault secret/ceq.JANUA_CLIENT_SECRET
-    # backfill is tracked in internal-devops runbooks until ESO is Ready again.
-    argocd.argoproj.io/ignore-healthcheck: "true"
 spec:
   refreshInterval: 15m
   secretStoreRef:
-    name: vault-store
+    name: ceq-kubernetes-store
     kind: ClusterSecretStore
   target:
     name: ceq-janua-client-secret
-    creationPolicy: Owner
+    creationPolicy: Merge
     deletionPolicy: Retain
   data:
     - secretKey: JANUA_CLIENT_SECRET
       remoteRef:
-        key: secret/ceq
+        key: ceq-janua-client-secret-source
         property: JANUA_CLIENT_SECRET
 ---

--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -50,6 +50,7 @@ resources:
 - worker-deployment.yaml
 - worker-orchestrator-deployment.yaml
 - db-migrate-job.yaml
+- ceq-kubernetes-secretstore.yaml
 - external-secret.yaml
 - network-policies.yaml
 - observability.yaml


### PR DESCRIPTION
## Summary
- Add `ceq-kubernetes-store` ClusterSecretStore for bridge secrets in the CEQ namespace
- Point `ceq-janua-client-secret` ExternalSecret at `ceq-janua-client-secret-source` until Vault `secret/ceq` has `JANUA_CLIENT_SECRET`
- Removes break-glass `ignore-healthcheck` annotation (no longer needed once bridge is bootstrapped)

## Bootstrap (already run in cluster)
`enclii/scripts/ga-ceq-bridge-bootstrap.sh`

## Test plan
- [x] `ceq-janua-client-secret` ESO → SecretSynced after live apply
- [ ] Argo `ceq-services` Healthy after merge + sync

Made with [Cursor](https://cursor.com)