### PR TITLE
fix(k8s): Owner policy for Janua bridge ExternalSecret

### DIFF
--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -104,7 +104,7 @@ spec:
     kind: ClusterSecretStore
   target:
     name: ceq-janua-client-secret
-    creationPolicy: Merge
+    creationPolicy: Owner
     deletionPolicy: Retain
   data:
     - secretKey: JANUA_CLIENT_SECRET


### PR DESCRIPTION
Follow-up to #64 — Owner recreates target secret from bridge source.

Made with [Cursor](https://cursor.com)