### PR TITLE
fix(infra): VAST from Vault secret/ceq

### DIFF
--- a/apps/api/tests/test_k8s_manifests.py
+++ b/apps/api/tests/test_k8s_manifests.py
@@ -37,12 +37,14 @@ def test_external_secret_includes_janua_client_secret() -> None:
     assert "property: JANUA_CLIENT_SECRET" in manifest
 
 
-def test_external_secret_includes_gpu_worker_secrets() -> None:
+def test_external_secret_orchestrator_reads_vast_from_vault() -> None:
     manifest = (REPO_ROOT / "infrastructure/k8s/external-secret.yaml").read_text()
 
-    for key in ("VAST_API_KEY", "FAL_API_KEY", "CEQ_WORKER_REDIS_URL"):
-        assert f"secretKey: {key}" in manifest
-        assert f"property: {key}" in manifest
+    assert "name: ceq-orchestrator-secrets" in manifest
+    assert "name: vault-store" in manifest
+    assert "secretKey: VAST_API_KEY" in manifest
+    assert "key: secret/ceq" in manifest
+    assert "property: vast_api_key" in manifest
 
 
 def test_orchestrator_deployment_uses_vast_control_plane() -> None:

--- a/infrastructure/k8s/external-secret.yaml
+++ b/infrastructure/k8s/external-secret.yaml
@@ -67,7 +67,7 @@ metadata:
 spec:
   refreshInterval: 15m
   secretStoreRef:
-    name: ceq-kubernetes-store
+    name: vault-store
     kind: ClusterSecretStore
   target:
     name: ceq-orchestrator-secrets
@@ -76,16 +76,8 @@ spec:
   data:
     - secretKey: VAST_API_KEY
       remoteRef:
-        key: ceq-orchestrator-secrets-source
-        property: VAST_API_KEY
-    - secretKey: FAL_API_KEY
-      remoteRef:
-        key: ceq-orchestrator-secrets-source
-        property: FAL_API_KEY
-    - secretKey: CEQ_WORKER_REDIS_URL
-      remoteRef:
-        key: ceq-orchestrator-secrets-source
-        property: CEQ_WORKER_REDIS_URL
+        key: secret/ceq
+        property: vast_api_key
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret


### PR DESCRIPTION
Unblocks ceq-orchestrator-secrets after P0 vast-api-key intake. Replaces kubernetes-store bridge with vault-store fan-out from secret/ceq.vast_api_key.

Made with [Cursor](https://cursor.com)