### PR TITLE
docs: state the AGPL core + MIT SDK license split consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ This project is licensed under the GNU Affero General Public License v3.0
 (AGPL-3.0-only), per the MADFAM public-repo licensing policy (RFC 0024 P1.4).
 See [LICENSE](./LICENSE) for the full text.
 
+**Exception:** the [`@ceq/sdk`](./packages/sdk/) client package is
+MIT-licensed so third parties can integrate it freely — see
+[packages/sdk/LICENSE](./packages/sdk/LICENSE).
+
 Copyright (c) 2026 Innovaciones MADFAM SAS de C.V.
 
 ---

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -431,4 +431,5 @@ kubectl port-forward -n ceq deployment/ceq-api 5800:5800
 
 ## License
 
-PROPRIETARY - MADFAM
+AGPL-3.0-only — see the repository root [LICENSE](../../LICENSE)
+(RFC 0024 P1.4; the `@ceq/sdk` client package is separately MIT-licensed).

--- a/apps/workers/README.md
+++ b/apps/workers/README.md
@@ -316,4 +316,5 @@ Per [PORT_ALLOCATION.md](https://github.com/madfam-io/solarpunk-foundry/blob/mai
 
 ## License
 
-PROPRIETARY - MADFAM
+AGPL-3.0-only — see the repository root [LICENSE](../../LICENSE)
+(RFC 0024 P1.4; the `@ceq/sdk` client package is separately MIT-licensed).


### PR DESCRIPTION
## Summary
Docs-only consistency pass after #68 (AGPL-3.0-only core + MIT `@ceq/sdk`):

- **README.md** — the License section stated AGPL-3.0-only with no mention of the SDK carve-out; adds the `@ceq/sdk` MIT exception with a link to `packages/sdk/LICENSE`.
- **apps/api/README.md**, **apps/workers/README.md** — both still said `PROPRIETARY - MADFAM`, contradicting the relicense; now point to the root AGPL-3.0-only LICENSE and note the SDK exception.

Verified against main: root `LICENSE` is the full AGPL v3 text, root `package.json` has `"license": "AGPL-3.0-only"`, `packages/sdk/package.json` has `"license": "MIT"` with its own MIT `LICENSE`, and `packages/sdk/README.md` already documents the split correctly. No other conflicting license claims found in ECOSYSTEM.md, AGENTS.md, llms*.txt, BRAND.md, or docs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX)_